### PR TITLE
Add IES case study foundation and portfolio SOTs

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -639,3 +639,241 @@ img {
     transform: none;
   }
 }
+
+/* IES case study page */
+.case-study-title {
+  font-family: var(--font-inter), system-ui, sans-serif;
+  font-weight: 100;
+  font-size: clamp(1.75rem, 4.5vw, 2.75rem);
+  line-height: 1.1;
+  letter-spacing: -0.02em;
+  text-transform: uppercase;
+  color: #f4f7f6;
+}
+
+.case-study-section {
+  margin-top: 3.5rem;
+}
+
+.case-study-heading {
+  font-family: var(--font-inter), system-ui, sans-serif;
+  font-weight: 100;
+  font-size: clamp(1.25rem, 3vw, 1.75rem);
+  line-height: 1.15;
+  letter-spacing: -0.02em;
+  color: #f4f7f6;
+}
+
+.case-study-body {
+  font-family: var(--font-inter), system-ui, sans-serif;
+  font-size: 0.9375rem;
+  font-weight: 300;
+  line-height: 1.7;
+  color: #a8b3b0;
+}
+
+.case-study-callout {
+  margin: 0;
+  padding: 1rem 1.25rem;
+  border-left: 2px solid #31f5d4;
+  font-family: var(--font-inter), system-ui, sans-serif;
+  font-size: 0.9375rem;
+  font-weight: 300;
+  font-style: italic;
+  line-height: 1.6;
+  color: #7ce7d6;
+  background: rgba(17, 23, 25, 0.6);
+  border-radius: 0 4px 4px 0;
+}
+
+.case-study-cta {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0.65rem 1.25rem;
+  border-radius: 9999px;
+  font-family: var(--font-inter), system-ui, sans-serif;
+  font-size: 0.8125rem;
+  text-decoration: none;
+  transition: border-color 200ms ease, color 200ms ease, transform 200ms ease;
+}
+
+.case-study-cta--primary {
+  background: #31f5d4;
+  color: #07110f;
+}
+
+.case-study-cta--primary:hover,
+.case-study-cta--primary:focus-visible {
+  transform: scale(1.02);
+}
+
+.case-study-cta--secondary {
+  border: 1px solid rgba(255, 255, 255, 0.18);
+  color: #f4f7f6;
+}
+
+.case-study-cta--secondary:hover,
+.case-study-cta--secondary:focus-visible {
+  border-color: rgba(49, 245, 212, 0.45);
+  color: #31f5d4;
+}
+
+/* IES sanitized visuals */
+.ies-visuals-grid {
+  display: flex;
+  flex-direction: column;
+  gap: 1.25rem;
+}
+
+.ies-visuals-grid__pair {
+  display: grid;
+  gap: 1.25rem;
+}
+
+@media (min-width: 640px) {
+  .ies-visuals-grid__pair {
+    grid-template-columns: 1fr 1fr;
+  }
+}
+
+.ies-visual {
+  margin: 0;
+  padding: 1.25rem;
+  border-radius: 6px;
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  background: #111719;
+  overflow-x: auto;
+}
+
+.ies-visual__caption {
+  margin: 0 0 1rem;
+  font-family: var(--font-inter), system-ui, sans-serif;
+  font-size: 0.6875rem;
+  font-weight: 400;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: #31f5d4;
+}
+
+.ies-visual__svg {
+  display: block;
+  width: 100%;
+  height: auto;
+  margin-bottom: 0.75rem;
+}
+
+.ies-flow-line {
+  animation: flowPulse 4.5s linear infinite;
+}
+
+.ies-visual__stages {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.ies-visual__stage {
+  flex: 1 1 auto;
+  min-width: 4.5rem;
+  padding: 0.5rem 0.65rem;
+  border-radius: 4px;
+  background: #0b0f10;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  text-align: center;
+}
+
+.ies-visual__stage-index {
+  display: block;
+  font-family: var(--font-mono);
+  font-size: 0.625rem;
+  color: #5e6865;
+}
+
+.ies-visual__stage-label {
+  display: block;
+  margin-top: 0.15rem;
+  font-family: var(--font-inter), system-ui, sans-serif;
+  font-size: 0.6875rem;
+  color: #f4f7f6;
+}
+
+.ies-visual__rail {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.ies-visual__rail-item {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  font-family: var(--font-inter), system-ui, sans-serif;
+  font-size: 0.75rem;
+  color: #a8b3b0;
+}
+
+.ies-visual__rail-dot {
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background: #31f5d4;
+  flex-shrink: 0;
+}
+
+.ies-visual__packet,
+.ies-visual__receipt {
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.65rem;
+}
+
+.ies-visual__packet-row,
+.ies-visual__receipt-row {
+  display: grid;
+  grid-template-columns: 7rem 1fr;
+  gap: 0.75rem;
+  align-items: baseline;
+}
+
+.ies-visual__packet-row dt,
+.ies-visual__receipt-row dt {
+  font-family: var(--font-inter), system-ui, sans-serif;
+  font-size: 0.625rem;
+  font-weight: 400;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: #5e6865;
+}
+
+.ies-visual__packet-row dd,
+.ies-visual__receipt-row dd {
+  margin: 0;
+  font-family: var(--font-inter), system-ui, sans-serif;
+  font-size: 0.75rem;
+  font-weight: 300;
+  color: #f4f7f6;
+}
+
+@media (max-width: 480px) {
+  .ies-visual__packet-row,
+  .ies-visual__receipt-row {
+    grid-template-columns: 1fr;
+    gap: 0.2rem;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .ies-flow-line {
+    animation: none;
+    stroke-dashoffset: 0;
+    opacity: 0.6;
+  }
+}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,6 +1,7 @@
 "use client"
 
 import { Mail, Linkedin, FileText } from "lucide-react"
+import Link from "next/link"
 import { useState, useEffect, useRef, useCallback } from "react"
 import Image from "next/image"
 import ClarityEngine from "@/components/portfolio/clarity-engine"
@@ -27,13 +28,13 @@ const PROJECTS = [
   {
     no: "01",
     title: "Intuit Enterprise Suite",
-    href: null as string | null,
+    href: "/work/intuit-enterprise-suite",
     label: "Enterprise SaaS · AI-native workflows · Financial systems",
     description:
       "Helped define and communicate AI-native product direction for complex enterprise finance workflows, translating ambiguity into clearer information architecture, prototype concepts, and leadership-ready product narratives.",
     outcome:
       "Helped make complex financial systems easier to understand, evaluate, and act on through evidence-backed product thinking, workflow design, and storytelling.",
-    cta: "Case study in progress",
+    cta: "View case study",
     feature: true,
   },
   {
@@ -304,11 +305,18 @@ export default function Home() {
                   <span className="text-[#F4F7F6]">Outcome: </span>
                   {p.outcome}
                 </p>
-                {p.cta && (
+                {p.cta && p.href ? (
+                  <Link
+                    href={p.href}
+                    className="mt-5 inline-flex font-ui text-[11px] uppercase tracking-[0.12em] text-[#31F5D4] transition-colors hover:text-[#7CE7D6]"
+                  >
+                    {p.cta} →
+                  </Link>
+                ) : p.cta ? (
                   <p className="mt-5 font-ui text-[11px] uppercase tracking-[0.12em] text-[#5E6865]">
                     {p.cta}
                   </p>
-                )}
+                ) : null}
               </article>
             ))}
           </div>

--- a/app/work/intuit-enterprise-suite/page.tsx
+++ b/app/work/intuit-enterprise-suite/page.tsx
@@ -1,0 +1,223 @@
+import type { Metadata } from "next"
+import Link from "next/link"
+import IALogotype from "@/components/ia-logotype"
+import IesCaseStudyVisuals from "@/components/IesCaseStudyVisuals"
+
+export const metadata: Metadata = {
+  title: "Defining an AI-native target state for enterprise finance — Ardavan Mirhosseini",
+  description:
+    "A public-safe case study about shaping AI-native product direction, information architecture, trust patterns, and storytelling for complex enterprise finance workflows.",
+}
+
+const PRINCIPLES = [
+  {
+    title: "Structure the system",
+    copy: "Map the entities, relationships, decisions, constraints, and failure points before designing the interface.",
+  },
+  {
+    title: "Make evidence visible",
+    copy: "Show the signals and source context behind a recommendation so people can understand why it matters.",
+  },
+  {
+    title: "Preserve human judgment",
+    copy: "Treat approval, escalation, and review as core parts of the experience — not friction to remove.",
+  },
+  {
+    title: "Close the loop",
+    copy: "After a decision, show what changed, what was recorded, and what can be reviewed later.",
+  },
+]
+
+const PATTERNS = [
+  {
+    title: "Evidence rail",
+    copy: "A supporting layer that gives users a clear trail of signals, assumptions, and source context.",
+  },
+  {
+    title: "Decision packet",
+    copy: "A structured object that brings together the recommendation, rationale, impact, risks, and next step.",
+  },
+  {
+    title: "Human judgment checkpoint",
+    copy: "A deliberate moment where the system asks for review, confirmation, or escalation before meaningful action.",
+  },
+  {
+    title: "Approval receipt",
+    copy: "A closing artifact that records what was approved, what changed, and where the user can review it later.",
+  },
+]
+
+const META = [
+  { label: "Role", value: "Product design, information architecture, prototyping, product storytelling" },
+  {
+    label: "Focus",
+    value: "AI-native workflows, enterprise finance, trust, explainability, human judgment",
+  },
+  {
+    label: "Output",
+    value: "Frameworks, sanitized patterns, prototype narratives, alignment artifacts",
+  },
+  { label: "Status", value: "Public-safe case study shell" },
+]
+
+export default function IesCaseStudyPage() {
+  return (
+    <main className="min-h-screen overflow-x-hidden bg-[#05070A] text-[#F4F7F6]">
+      <header className="border-b border-[rgba(255,255,255,0.08)] bg-[#05070A]/90 backdrop-blur-md">
+        <div className="mx-auto flex h-16 max-w-3xl items-center justify-between px-6 lg:px-8">
+          <IALogotype />
+          <Link
+            href="/#work"
+            className="font-mono text-xs uppercase tracking-[0.16em] text-[#A8B3B0] transition-colors hover:text-[#31F5D4]"
+          >
+            Back to work
+          </Link>
+        </div>
+      </header>
+
+      <article className="mx-auto max-w-3xl px-6 py-16 lg:px-8 lg:py-24">
+        <p className="font-mono text-xs uppercase tracking-[0.16em] text-[#5E6865]">
+          Intuit Enterprise Suite · Enterprise SaaS · AI-native workflows
+        </p>
+        <h1 className="case-study-title mt-4">
+          Defining an AI-native target state for enterprise finance
+        </h1>
+        <p className="mt-6 font-body text-base leading-relaxed text-[#A8B3B0] sm:text-lg">
+          I helped define and communicate AI-native product direction for complex enterprise
+          finance workflows — translating ambiguity into clearer information architecture, trust
+          patterns, prototype concepts, and leadership-ready product narratives.
+        </p>
+        <p className="mt-4 rounded-[4px] border border-[rgba(49,245,212,0.18)] bg-[#111719] p-4 font-body text-[13px] leading-relaxed text-[#A8B3B0]">
+          This public case study is intentionally sanitized. It focuses on approach, systems
+          thinking, and design patterns rather than confidential product details, internal
+          screenshots, or roadmap specifics.
+        </p>
+
+        <dl className="mt-10 grid gap-4 sm:grid-cols-2">
+          {META.map((item) => (
+            <div key={item.label} className="rounded-[6px] border border-[rgba(255,255,255,0.12)] bg-[#111719] p-4">
+              <dt className="font-ui text-[10px] uppercase tracking-[0.14em] text-[#31F5D4]">
+                {item.label}
+              </dt>
+              <dd className="mt-2 font-body text-[13px] leading-relaxed text-[#F4F7F6]">
+                {item.value}
+              </dd>
+            </div>
+          ))}
+        </dl>
+
+        <section className="case-study-section">
+          <h2 className="case-study-heading">Context</h2>
+          <p className="case-study-body">
+            Enterprise finance workflows are dense, high-stakes, and full of dependencies. People
+            need to understand what changed, why it matters, what evidence supports it, who needs to
+            act, and what happens after an action is taken.
+          </p>
+          <p className="case-study-body mt-4">
+            As AI becomes more present in business software, the design challenge is not simply
+            making systems more automated. The challenge is making intelligent systems
+            understandable, trustworthy, and useful in moments where human judgment still matters.
+          </p>
+        </section>
+
+        <section className="case-study-section">
+          <h2 className="case-study-heading">The challenge was not &ldquo;add AI.&rdquo; It was make AI legible.</h2>
+          <p className="case-study-body">
+            In high-trust financial workflows, a smart recommendation is only useful if people can
+            evaluate it. The experience needed to make reasoning visible, clarify risk, show
+            supporting evidence, and preserve user control before any meaningful decision or
+            action.
+          </p>
+          <blockquote className="case-study-callout mt-6">
+            Make the system legible before making it smart.
+          </blockquote>
+        </section>
+
+        <section className="case-study-section">
+          <h2 className="case-study-heading">My role</h2>
+          <p className="case-study-body">
+            I contributed to the product direction by translating complex enterprise finance
+            concepts into clearer experience models, information architecture, prototype concepts,
+            and leadership-ready narratives. My work focused on helping teams reason through
+            ambiguity, trust, evidence, authorization, and the role of human oversight in AI-native
+            workflows.
+          </p>
+        </section>
+
+        <section className="case-study-section">
+          <h2 className="case-study-heading">How I made the system legible</h2>
+          <div className="mt-6 grid gap-4 sm:grid-cols-2">
+            {PRINCIPLES.map((p, i) => (
+              <div key={p.title} className="rounded-[6px] bg-[#111719] p-5">
+                <span className="font-display text-sm text-[#31F5D4]">
+                  {String(i + 1).padStart(2, "0")}
+                </span>
+                <h3 className="mt-2 font-ui text-sm text-[#F4F7F6]">{p.title}</h3>
+                <p className="mt-2 font-body text-[13px] leading-relaxed text-[#A8B3B0]">
+                  {p.copy}
+                </p>
+              </div>
+            ))}
+          </div>
+        </section>
+
+        <section className="case-study-section">
+          <h2 className="case-study-heading">Sanitized design patterns</h2>
+          <div className="mt-6 grid gap-4 sm:grid-cols-2">
+            {PATTERNS.map((p) => (
+              <div
+                key={p.title}
+                className="rounded-[6px] border border-[rgba(255,255,255,0.08)] bg-[#0B0F10] p-5"
+              >
+                <h3 className="font-ui text-[11px] uppercase tracking-[0.12em] text-[#7CE7D6]">
+                  {p.title}
+                </h3>
+                <p className="mt-2 font-body text-[13px] leading-relaxed text-[#A8B3B0]">
+                  {p.copy}
+                </p>
+              </div>
+            ))}
+          </div>
+        </section>
+
+        <section className="case-study-section">
+          <h2 className="case-study-heading">Abstract visuals</h2>
+          <p className="case-study-body mb-6">
+            Synthetic diagrams showing the thinking behind trust patterns — generic labels only, no
+            confidential product UI.
+          </p>
+          <IesCaseStudyVisuals />
+        </section>
+
+        <section className="case-study-section">
+          <h2 className="case-study-heading">What changed</h2>
+          <p className="case-study-body">
+            The work helped make an abstract AI-native ambition easier to understand, evaluate,
+            and discuss. By turning complex financial workflows into clearer frameworks, patterns,
+            and narratives, the direction became more tangible for cross-functional partners and
+            leadership audiences.
+          </p>
+        </section>
+
+        <section className="case-study-section">
+          <h2 className="case-study-heading">Reflection</h2>
+          <p className="case-study-body">
+            The most important lesson was that trustworthy AI is not only about model capability.
+            It is about the surrounding experience: the information architecture, evidence,
+            controls, language, and moments of human judgment that help people understand what the
+            system is doing and why it matters.
+          </p>
+        </section>
+
+        <footer className="mt-16 flex flex-wrap gap-4 border-t border-[rgba(255,255,255,0.12)] pt-10">
+          <Link href="/#work" className="case-study-cta case-study-cta--primary">
+            Back to selected work
+          </Link>
+          <Link href="/#contact" className="case-study-cta case-study-cta--secondary">
+            Ask Ardavan about this work
+          </Link>
+        </footer>
+      </article>
+    </main>
+  )
+}

--- a/app/work/intuit-enterprise-suite/page.tsx
+++ b/app/work/intuit-enterprise-suite/page.tsx
@@ -57,7 +57,7 @@ const META = [
     label: "Output",
     value: "Frameworks, sanitized patterns, prototype narratives, alignment artifacts",
   },
-  { label: "Status", value: "Public-safe case study shell" },
+  { label: "Status", value: "Public-safe case study" },
 ]
 
 export default function IesCaseStudyPage() {
@@ -214,7 +214,7 @@ export default function IesCaseStudyPage() {
             Back to selected work
           </Link>
           <Link href="/#contact" className="case-study-cta case-study-cta--secondary">
-            Ask Ardavan about this work
+            Get in touch
           </Link>
         </footer>
       </article>

--- a/components/IesCaseStudyVisuals.tsx
+++ b/components/IesCaseStudyVisuals.tsx
@@ -1,0 +1,126 @@
+/**
+ * Sanitized abstract visuals for the IES public case study.
+ * Generic labels and synthetic data only — no confidential UI.
+ */
+
+function SystemMap() {
+  const stages = ["State", "Signal", "Evidence", "Decision", "Action"]
+  return (
+    <figure className="ies-visual ies-visual--map" aria-labelledby="ies-visual-map-title">
+      <figcaption id="ies-visual-map-title" className="ies-visual__caption">
+        Complexity → clarity system map
+      </figcaption>
+      <svg
+        className="ies-visual__svg"
+        viewBox="0 0 640 80"
+        role="img"
+        aria-label="Flow from state to signal to evidence to decision to action"
+      >
+        <line
+          x1="24"
+          y1="40"
+          x2="616"
+          y2="40"
+          stroke="#31F5D4"
+          strokeWidth="1.5"
+          strokeDasharray="6 8"
+          className="ies-flow-line"
+        />
+      </svg>
+      <ol className="ies-visual__stages">
+        {stages.map((stage, i) => (
+          <li key={stage} className="ies-visual__stage">
+            <span className="ies-visual__stage-index">{String(i + 1).padStart(2, "0")}</span>
+            <span className="ies-visual__stage-label">{stage}</span>
+          </li>
+        ))}
+      </ol>
+    </figure>
+  )
+}
+
+function EvidenceRail() {
+  const items = [
+    "Source context",
+    "Policy check",
+    "Materiality signal",
+    "Confidence note",
+  ]
+  return (
+    <figure className="ies-visual" aria-labelledby="ies-visual-rail-title">
+      <figcaption id="ies-visual-rail-title" className="ies-visual__caption">
+        Evidence rail
+      </figcaption>
+      <ul className="ies-visual__rail">
+        {items.map((item) => (
+          <li key={item} className="ies-visual__rail-item">
+            <span className="ies-visual__rail-dot" aria-hidden="true" />
+            {item}
+          </li>
+        ))}
+      </ul>
+    </figure>
+  )
+}
+
+function DecisionPacket() {
+  const fields = [
+    { label: "Recommendation", value: "Review classification variance" },
+    { label: "Evidence", value: "3 supporting signals attached" },
+    { label: "Risk", value: "Medium — requires human review" },
+    { label: "Human review", value: "Pending approval" },
+    { label: "Approval state", value: "Awaiting decision" },
+  ]
+  return (
+    <figure className="ies-visual" aria-labelledby="ies-visual-packet-title">
+      <figcaption id="ies-visual-packet-title" className="ies-visual__caption">
+        Decision packet
+      </figcaption>
+      <dl className="ies-visual__packet">
+        {fields.map((f) => (
+          <div key={f.label} className="ies-visual__packet-row">
+            <dt>{f.label}</dt>
+            <dd>{f.value}</dd>
+          </div>
+        ))}
+      </dl>
+    </figure>
+  )
+}
+
+function ApprovalReceipt() {
+  const fields = [
+    { label: "Decision recorded", value: "Classification review approved" },
+    { label: "Reviewer", value: "Finance lead" },
+    { label: "Time", value: "Synthetic timestamp" },
+    { label: "Follow-up", value: "Audit trail available" },
+  ]
+  return (
+    <figure className="ies-visual" aria-labelledby="ies-visual-receipt-title">
+      <figcaption id="ies-visual-receipt-title" className="ies-visual__caption">
+        Approval receipt
+      </figcaption>
+      <dl className="ies-visual__receipt">
+        {fields.map((f) => (
+          <div key={f.label} className="ies-visual__receipt-row">
+            <dt>{f.label}</dt>
+            <dd>{f.value}</dd>
+          </div>
+        ))}
+      </dl>
+    </figure>
+  )
+}
+
+export default function IesCaseStudyVisuals() {
+  return (
+    <div className="ies-visuals-grid">
+      <SystemMap />
+      <div className="ies-visuals-grid__pair">
+        <EvidenceRail />
+        <DecisionPacket />
+      </div>
+      <ApprovalReceipt />
+    </div>
+  )
+}

--- a/content/ask-ardavan.ts
+++ b/content/ask-ardavan.ts
@@ -67,6 +67,12 @@ export const ASK_ARDAVAN_PROMPTS: AskArdavanPrompt[] = [
     assistantTitle: "Intuit Enterprise Suite",
     answer:
       "My IES work centers on helping define and communicate AI-native product direction for complex enterprise finance workflows. The public version focuses on information architecture, workflow clarity, explainability, and leadership-ready storytelling.",
+    links: [
+      {
+        label: "View the public-safe IES case study",
+        href: "/work/intuit-enterprise-suite",
+      },
+    ],
   },
   {
     id: "founder",

--- a/docs/sot/changelog.md
+++ b/docs/sot/changelog.md
@@ -1,0 +1,10 @@
+# Portfolio Changelog (Sprint Docs)
+
+## 2026-07-09 — Portfolio Sprint 2 — IES Case Study Foundation
+
+- Started Portfolio Sprint 2 — IES Case Study Foundation
+- Added public-safe SOT docs: roadmap, claims log, IES case study SOT, sanitized visual plan
+- Started IES case study route at `/work/intuit-enterprise-suite`
+- Added sanitized abstract visual direction and components
+- Linked homepage IES card and Ask Ardavan IES prompt to case study
+- Preserved public-content and claims guardrails

--- a/docs/sot/ies-case-study-sot.md
+++ b/docs/sot/ies-case-study-sot.md
@@ -2,7 +2,7 @@
 
 Version: 1.0  
 Last updated: 2026-07-09  
-Status: Public-safe shell
+Status: Public-safe case study
 
 ## Public case study route
 

--- a/docs/sot/ies-case-study-sot.md
+++ b/docs/sot/ies-case-study-sot.md
@@ -1,0 +1,65 @@
+# IES Case Study SOT — Public-Safe Version
+
+Version: 1.0  
+Last updated: 2026-07-09  
+Status: Public-safe shell
+
+## Public case study route
+
+`/work/intuit-enterprise-suite`
+
+## Working title
+
+Defining an AI-native target state for enterprise finance
+
+## Public-safe one-liner
+
+Helped define and communicate AI-native product direction for complex enterprise finance workflows, translating ambiguity into clearer information architecture, trust patterns, prototype concepts, and leadership-ready product narratives.
+
+## Case study sections
+
+1. Context
+2. The challenge
+3. My role
+4. Why trust mattered
+5. How I made the system legible
+6. Key design patterns
+7. Prototype and storytelling artifacts
+8. What changed
+9. Reflection
+
+## Approved public-safe themes
+
+- Enterprise finance complexity
+- AI-native workflows
+- Information architecture
+- Explainability
+- Evidence
+- Human judgment
+- User control
+- Authorization
+- Product storytelling
+- Leadership alignment
+
+## Do not publish
+
+- Internal screenshots
+- Internal deck language
+- Raw source-pack text
+- Customer names
+- Fictional persona names from internal work
+- Internal prototype names
+- Exact roadmap details
+- Exact launch dates
+- Unverified outcomes
+- Private recognition quotes
+- Metrics (including percentages)
+
+## Open verification questions
+
+- Preferred public title
+- Whether to show a date range
+- Exact role wording
+- Which sanitized artifacts Ardavan personally wants to claim
+- Whether “Intuit Enterprise Suite” can appear in the public case study title
+- Whether any outcomes can be verified later

--- a/docs/sot/portfolio-claims-log.md
+++ b/docs/sot/portfolio-claims-log.md
@@ -1,0 +1,15 @@
+# Portfolio Claims Log
+
+Version: 1.0  
+Last updated: 2026-07-09  
+Status: Public-safe
+
+| Claim | Status | Public wording | Notes |
+|-------|--------|----------------|-------|
+| Ardavan designs AI-native enterprise products that make financial complexity legible. | PUBLIC_SAFE | I design AI-native enterprise products that make financial complexity legible. | Current homepage positioning. |
+| IES work involved AI-native enterprise finance direction. | PUBLIC_SAFE (conservative) | Helped define and communicate AI-native product direction for complex enterprise finance workflows. | Use “helped define and communicate,” not “led” or “launched.” |
+| IES work involved IA, workflow clarity, trust, evidence, authorization, human judgment, prototype direction, and leadership storytelling. | PUBLIC_SAFE when abstracted | The work focused on making complex financial workflows clearer through information architecture, trust patterns, evidence, human judgment, prototypes, and product storytelling. | Do not name internal frameworks or prototypes. |
+| The IES concepts shipped, launched, or drove adoption. | DO_NOT_PUBLISH | Do not use. | Not verified. |
+| The IES work improved business metrics. | DO_NOT_PUBLISH | Do not use. | No unverified metrics. |
+| Recognitions praised executive storytelling and making complex capabilities tangible. | PRIVATE_CONTEXT | Recognized for turning complex AI and enterprise finance concepts into clear, tangible product stories. | Do not publish raw screenshots or private quotes. |
+| Internal source-pack terminology and prototype names. | DO_NOT_PUBLISH | Do not use. | Keep outside public repo unless explicitly approved. |

--- a/docs/sot/portfolio-roadmap.md
+++ b/docs/sot/portfolio-roadmap.md
@@ -1,0 +1,67 @@
+# Portfolio Roadmap
+
+Version: 1.0  
+Last updated: 2026-07-09  
+Status: Public-safe
+
+## Current status
+
+- Homepage is live with AI-native legibility positioning
+- Résumé PDF is live at `/resume-ardavan-mir.pdf`
+- Static guided Ask Ardavan chat is live
+- IES and QBOA cards still need case study depth (IES foundation in progress)
+
+## Priority order
+
+### P0 — Keep live site stable
+
+- Preserve accessibility, mobile responsiveness, static export, CNAME, and deployment config
+- Avoid confidential content and unverified claims
+
+### P1 — IES public case study
+
+- Build NDA-safe IES public case study
+- Create sanitized visuals for IES
+- Link homepage and Ask Ardavan to the IES case study
+- Create deeper private interview walkthrough later, outside public repo if sensitive
+
+### P2 — Expand portfolio depth
+
+- Create QBOA / Dimensional Chart of Accounts case study shell
+- Add project-card abstract visuals
+- Add Ask Ardavan V1.5 suggested next prompts
+- Add “What teams bring me in for” proof section
+
+### P3 — Polish and legacy work
+
+- Add writing/thinking note
+- Add OG/social preview polish
+- Add older projects only after scope and claims are verified
+
+## Sprint 2 scope
+
+Portfolio Sprint 2 — IES Case Study Foundation
+
+- SOT docs (public-safe)
+- IES public case study route at `/work/intuit-enterprise-suite`
+- Sanitized abstract visuals
+- Homepage IES link
+- Ask Ardavan IES link
+- Build QA
+
+## Later backlog
+
+- IES sanitized visual polish
+- QBOA case study shell
+- Ask Ardavan suggested next prompts
+- Proof section expansion
+- OG/social preview assets
+
+## Out of scope
+
+- Real AI chat
+- Backend/API routes
+- Confidential materials in repo
+- QBOA full case study (this sprint)
+- Unverified metrics
+- Production merge without review

--- a/docs/sot/sanitized-visual-plan.md
+++ b/docs/sot/sanitized-visual-plan.md
@@ -1,0 +1,34 @@
+# Sanitized Visual Plan
+
+Version: 1.0  
+Last updated: 2026-07-09  
+Status: Public-safe
+
+## Purpose
+
+Create case study visuals that show thinking and craft without exposing confidential product details.
+
+## Visuals to build for IES V1
+
+1. Complexity → clarity system map
+2. State → signal → evidence → decision → action loop
+3. Evidence rail
+4. Decision packet
+5. Human judgment checkpoint
+6. Approval receipt
+
+## Rules
+
+- Use abstract diagrams
+- Use synthetic labels
+- Use fictional, generic data only
+- Do not mimic internal UI exactly
+- Do not use real product screenshots
+- Do not use Intuit visual styling beyond public-safe textual references
+- Match existing portfolio design system (Glass Monolith / Legibility Layer)
+- Keep visuals lightweight using CSS/SVG/HTML
+- No image-heavy assets unless necessary
+
+## V1 implementation
+
+Implemented in `components/IesCaseStudyVisuals.tsx` as abstract SVG/HTML diagrams with generic synthetic labels.


### PR DESCRIPTION
## Summary
Adds the first public-safe Intuit Enterprise Suite case study foundation and documents the next portfolio roadmap in repo SOTs.

## Included
- Public-safe portfolio roadmap SOT
- Public-safe claims log
- IES case study SOT
- Sanitized visual plan
- Changelog entry
- /work/intuit-enterprise-suite case study route
- Abstract/sanitized IES visuals
- Homepage IES card link
- Ask Ardavan IES case study link

## Safety
- No confidential screenshots
- No private recognition quotes
- No customer names
- No internal roadmap details
- No unverified metrics
- No claims of launch, adoption, or business impact
- No backend/API/OpenAI changes
- No new dependencies

## QA
- pnpm build passed

Made with [Cursor](https://cursor.com)