### PR TITLE
Add QBOA case study foundation and polish IES visuals

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -877,3 +877,323 @@ img {
     opacity: 0.6;
   }
 }
+
+/* IES visual polish */
+.ies-visual__blurb {
+  margin: 0 0 1rem;
+  font-family: var(--font-inter), system-ui, sans-serif;
+  font-size: 0.8125rem;
+  font-weight: 300;
+  line-height: 1.55;
+  color: #a8b3b0;
+}
+
+.ies-visual__svg--map {
+  margin-bottom: 0.25rem;
+}
+
+.ies-visual__rail-label {
+  flex: 0 0 auto;
+  min-width: 7rem;
+}
+
+.ies-visual__rail-bar {
+  flex: 1;
+  height: 3px;
+  border-radius: 2px;
+  background: linear-gradient(90deg, rgba(49, 245, 212, 0.55), rgba(49, 245, 212, 0.15));
+  max-width: 5rem;
+}
+
+.ies-visual__packet-row--highlight {
+  padding: 0.35rem 0.5rem;
+  margin: -0.35rem -0.5rem;
+  border-radius: 4px;
+  background: rgba(49, 245, 212, 0.06);
+  border-left: 2px solid rgba(49, 245, 212, 0.45);
+}
+
+.ies-visual__checkpoint-lane {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.5rem;
+  margin-bottom: 1rem;
+}
+
+.ies-visual__checkpoint-node {
+  padding: 0.4rem 0.65rem;
+  border-radius: 4px;
+  font-family: var(--font-inter), system-ui, sans-serif;
+  font-size: 0.6875rem;
+  color: #a8b3b0;
+  background: #0b0f10;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+}
+
+.ies-visual__checkpoint-gate {
+  padding: 0.5rem 0.85rem;
+  border-radius: 6px;
+  background: rgba(255, 122, 102, 0.08);
+  border: 1px dashed rgba(255, 122, 102, 0.45);
+}
+
+.ies-visual__checkpoint-gate-label {
+  font-family: var(--font-inter), system-ui, sans-serif;
+  font-size: 0.6875rem;
+  font-weight: 400;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  color: #ff9a8a;
+}
+
+.ies-visual__checkpoint-arrow {
+  font-family: var(--font-mono);
+  font-size: 0.75rem;
+  color: #5e6865;
+}
+
+.ies-visual__checkpoint-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.ies-visual__checkpoint-actions li {
+  padding: 0.35rem 0.65rem;
+  border-radius: 9999px;
+  font-family: var(--font-inter), system-ui, sans-serif;
+  font-size: 0.625rem;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: #7ce7d6;
+  border: 1px solid rgba(49, 245, 212, 0.25);
+  background: rgba(49, 245, 212, 0.06);
+}
+
+.ies-visual__receipt-stamp {
+  align-self: flex-start;
+  margin-top: 0.5rem;
+  padding: 0.25rem 0.6rem;
+  border-radius: 4px;
+  font-family: var(--font-mono);
+  font-size: 0.625rem;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: #31f5d4;
+  border: 1px solid rgba(49, 245, 212, 0.35);
+}
+
+/* Shared case study visuals (QBOA) */
+.case-visuals-grid {
+  display: flex;
+  flex-direction: column;
+  gap: 1.25rem;
+}
+
+.case-visuals-grid__pair {
+  display: grid;
+  gap: 1.25rem;
+}
+
+@media (min-width: 640px) {
+  .case-visuals-grid__pair {
+    grid-template-columns: 1fr 1fr;
+  }
+}
+
+.case-visual {
+  margin: 0;
+  padding: 1.25rem;
+  border-radius: 6px;
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  background: #111719;
+  overflow-x: auto;
+}
+
+.case-visual__caption {
+  margin: 0 0 0.5rem;
+  font-family: var(--font-inter), system-ui, sans-serif;
+  font-size: 0.6875rem;
+  font-weight: 400;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: #31f5d4;
+}
+
+.case-visual__blurb {
+  margin: 0 0 1rem;
+  font-family: var(--font-inter), system-ui, sans-serif;
+  font-size: 0.8125rem;
+  font-weight: 300;
+  line-height: 1.55;
+  color: #a8b3b0;
+}
+
+.case-visual__svg {
+  display: block;
+  width: 100%;
+  height: auto;
+}
+
+.case-visual__fields {
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.65rem;
+}
+
+.case-visual__field-row {
+  display: grid;
+  grid-template-columns: 7rem 1fr;
+  gap: 0.75rem;
+  align-items: baseline;
+}
+
+.case-visual__field-row dt {
+  font-family: var(--font-inter), system-ui, sans-serif;
+  font-size: 0.625rem;
+  font-weight: 400;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: #5e6865;
+}
+
+.case-visual__field-row dd {
+  margin: 0;
+  font-family: var(--font-inter), system-ui, sans-serif;
+  font-size: 0.75rem;
+  font-weight: 300;
+  color: #f4f7f6;
+}
+
+.qboa-visual__grid {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+  font-family: var(--font-inter), system-ui, sans-serif;
+  font-size: 0.75rem;
+}
+
+.qboa-visual__grid-header,
+.qboa-visual__grid-row {
+  display: grid;
+  grid-template-columns: 1fr 1fr 1fr;
+  gap: 0.5rem;
+}
+
+.qboa-visual__grid-header span {
+  font-size: 0.625rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: #5e6865;
+}
+
+.qboa-visual__grid-cell {
+  padding: 0.45rem 0.5rem;
+  border-radius: 4px;
+  background: #0b0f10;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  color: #a8b3b0;
+}
+
+.qboa-visual__layers {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+  display: flex;
+  flex-direction: column;
+  gap: 0.45rem;
+}
+
+.qboa-visual__layer {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.5rem 0.65rem;
+  border-radius: 4px;
+  background: #0b0f10;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  font-family: var(--font-inter), system-ui, sans-serif;
+  font-size: 0.75rem;
+  color: #a8b3b0;
+}
+
+.qboa-visual__layer-index {
+  font-family: var(--font-mono);
+  font-size: 0.625rem;
+  color: #31f5d4;
+}
+
+.qboa-visual__review-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  margin-top: 1rem;
+}
+
+.qboa-visual__review-btn {
+  padding: 0.35rem 0.75rem;
+  border-radius: 9999px;
+  font-family: var(--font-inter), system-ui, sans-serif;
+  font-size: 0.625rem;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: #a8b3b0;
+  border: 1px solid rgba(255, 255, 255, 0.15);
+}
+
+.qboa-visual__review-btn--primary {
+  color: #07110f;
+  background: #31f5d4;
+  border-color: #31f5d4;
+}
+
+/* Homepage project card mini-visuals */
+.project-card-visual {
+  margin-top: 0.75rem;
+  padding: 0.75rem;
+  border-radius: 4px;
+  background: #0b0f10;
+  border: 1px solid rgba(255, 255, 255, 0.06);
+  max-height: 5.5rem;
+  overflow: hidden;
+}
+
+.project-card-visual__svg {
+  display: block;
+  width: 100%;
+  height: auto;
+}
+
+.project-card-visual__grid {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 0.35rem;
+}
+
+.project-card-visual__grid-cell {
+  padding: 0.35rem;
+  border-radius: 3px;
+  font-family: var(--font-mono);
+  font-size: 0.5625rem;
+  text-align: center;
+  color: #7ce7d6;
+  background: rgba(49, 245, 212, 0.06);
+  border: 1px solid rgba(49, 245, 212, 0.15);
+}
+
+@media (max-width: 480px) {
+  .case-visual__field-row {
+    grid-template-columns: 1fr;
+    gap: 0.2rem;
+  }
+
+  .qboa-visual__grid-header,
+  .qboa-visual__grid-row {
+    grid-template-columns: 1fr;
+  }
+}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -7,6 +7,7 @@ import Image from "next/image"
 import ClarityEngine from "@/components/portfolio/clarity-engine"
 import IALogotype from "@/components/ia-logotype"
 import PortfolioChat from "@/components/PortfolioChat"
+import ProjectCardVisual from "@/components/ProjectCardVisual"
 
 const NAV = [
   { id: "work", label: "Work" },
@@ -36,18 +37,20 @@ const PROJECTS = [
       "Helped make complex financial systems easier to understand, evaluate, and act on through evidence-backed product thinking, workflow design, and storytelling.",
     cta: "View case study",
     feature: true,
+    visual: "ies" as const,
   },
   {
     no: "02",
     title: "QuickBooks Online Advanced — Dimensional Chart of Accounts",
-    href: null as string | null,
+    href: "/work/quickbooks-dimensional-chart-of-accounts",
     label: "Advanced accounting · IA · Classification & reporting",
     description:
       "Shaped advanced accounting workflows that help teams understand multi-dimensional classification, reporting, and decision-making inside a complex financial product.",
     outcome:
       "Created clearer structure around dense accounting workflows and financial information architecture.",
-    cta: "Case study in progress",
+    cta: "View case study",
     feature: true,
+    visual: "qboa" as const,
   },
   {
     no: "03",
@@ -294,7 +297,8 @@ export default function Home() {
                 <div className="mb-4">
                   <span className="font-display text-[1.75rem] text-[#31F5D4]">{p.no}</span>
                 </div>
-                <h3 className="monolith-title monolith-title--card">{p.title}</h3>
+                {"visual" in p && p.visual ? <ProjectCardVisual variant={p.visual} /> : null}
+                <h3 className="monolith-title monolith-title--card mt-4">{p.title}</h3>
                 <p className="mt-2 font-ui text-[12px] uppercase tracking-[0.12em] text-[#7CE7D6]">
                   {p.label}
                 </p>
@@ -335,21 +339,24 @@ export default function Home() {
                 rel="noopener noreferrer"
                 className="group flex flex-col gap-2 rounded-[6px] border border-[rgba(255,255,255,0.12)] bg-[#0B0F10] p-5 transition-colors hover:border-[#31F5D4]/30 sm:flex-row sm:items-center sm:justify-between"
               >
-                <div>
-                  <div className="flex items-center gap-3">
-                    <span className="font-display text-[1.5rem] text-[#31F5D4]">{p.no}</span>
-                    <h3 className="monolith-title monolith-title--card">{p.title}</h3>
+                <div className="flex flex-1 flex-col gap-3 sm:flex-row sm:items-center sm:gap-5">
+                  <ProjectCardVisual variant="community" />
+                  <div>
+                    <div className="flex items-center gap-3">
+                      <span className="font-display text-[1.5rem] text-[#31F5D4]">{p.no}</span>
+                      <h3 className="monolith-title monolith-title--card">{p.title}</h3>
+                    </div>
+                    <p className="mt-1 font-ui text-[12px] uppercase tracking-[0.12em] text-[#7CE7D6]">
+                      {p.label}
+                    </p>
+                    <p className="mt-2 font-body text-[13px] leading-relaxed text-[#A8B3B0]">
+                      {p.description}
+                    </p>
+                    <p className="mt-2 font-body text-[13px] leading-relaxed text-[#A8B3B0]">
+                      <span className="text-[#F4F7F6]">Outcome: </span>
+                      {p.outcome}
+                    </p>
                   </div>
-                  <p className="mt-1 font-ui text-[12px] uppercase tracking-[0.12em] text-[#7CE7D6]">
-                    {p.label}
-                  </p>
-                  <p className="mt-2 font-body text-[13px] leading-relaxed text-[#A8B3B0]">
-                    {p.description}
-                  </p>
-                  <p className="mt-2 font-body text-[13px] leading-relaxed text-[#A8B3B0]">
-                    <span className="text-[#F4F7F6]">Outcome: </span>
-                    {p.outcome}
-                  </p>
                 </div>
                 <span className="shrink-0 font-ui text-xs text-[#A8B3B0] transition-colors group-hover:text-[#31F5D4]">
                   iranianxdesign.com →

--- a/app/work/quickbooks-dimensional-chart-of-accounts/page.tsx
+++ b/app/work/quickbooks-dimensional-chart-of-accounts/page.tsx
@@ -1,0 +1,216 @@
+import type { Metadata } from "next"
+import Link from "next/link"
+import IALogotype from "@/components/ia-logotype"
+import QboaCaseStudyVisuals from "@/components/QboaCaseStudyVisuals"
+
+export const metadata: Metadata = {
+  title: "Designing information architecture for advanced accounting workflows — Ardavan Mirhosseini",
+  description:
+    "A public-safe case study shell about shaping advanced accounting workflows, dimensional classification, reporting clarity, and information architecture.",
+}
+
+const PRINCIPLES = [
+  {
+    title: "Make dimensions understandable",
+    copy: "Help users see what each dimension means, how it relates to others, and where it shows up in their workflow.",
+  },
+  {
+    title: "Show structure in context",
+    copy: "Surface classification and reporting structure where people need it — not as an abstract settings layer.",
+  },
+  {
+    title: "Reduce classification ambiguity",
+    copy: "Clarify labels, relationships, and consequences so teams can classify with more confidence.",
+  },
+  {
+    title: "Support reporting confidence",
+    copy: "Connect classification choices to reporting views and decision context people can evaluate.",
+  },
+]
+
+const PATTERNS = [
+  {
+    title: "Dimensional classification grid",
+    copy: "A structured view that helps teams see how classifications relate across multiple dimensions.",
+  },
+  {
+    title: "Reporting context layer",
+    copy: "A layer that connects classification choices to the reporting views and decisions they affect.",
+  },
+  {
+    title: "Account structure model",
+    copy: "An abstract model that makes hierarchy and relationships easier to understand at a glance.",
+  },
+  {
+    title: "Review and confirmation moment",
+    copy: "A deliberate step where users can confirm classification before it affects downstream reporting.",
+  },
+]
+
+const META = [
+  { label: "Role", value: "Product design, information architecture, workflow design" },
+  {
+    label: "Focus",
+    value: "Advanced accounting, dimensional classification, reporting clarity",
+  },
+  {
+    label: "Output",
+    value: "IA models, workflow concepts, product patterns, cross-functional artifacts",
+  },
+  { label: "Status", value: "Public-safe case study foundation" },
+]
+
+export default function QboaCaseStudyPage() {
+  return (
+    <main className="min-h-screen overflow-x-hidden bg-[#05070A] text-[#F4F7F6]">
+      <header className="border-b border-[rgba(255,255,255,0.08)] bg-[#05070A]/90 backdrop-blur-md">
+        <div className="mx-auto flex h-16 max-w-3xl items-center justify-between px-6 lg:px-8">
+          <IALogotype />
+          <Link
+            href="/#work"
+            className="font-mono text-xs uppercase tracking-[0.16em] text-[#A8B3B0] transition-colors hover:text-[#31F5D4] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#31F5D4]"
+          >
+            Back to work
+          </Link>
+        </div>
+      </header>
+
+      <article className="mx-auto max-w-3xl px-6 py-16 lg:px-8 lg:py-24">
+        <p className="font-mono text-xs uppercase tracking-[0.16em] text-[#5E6865]">
+          QuickBooks Online Advanced · Advanced accounting · Information architecture
+        </p>
+        <h1 className="case-study-title mt-4">
+          Designing information architecture for advanced accounting workflows
+        </h1>
+        <p className="mt-6 font-body text-base leading-relaxed text-[#A8B3B0] sm:text-lg">
+          I shaped advanced accounting workflows that help teams understand multi-dimensional
+          classification, reporting, and decision-making inside a complex financial product.
+        </p>
+        <p className="mt-4 rounded-[4px] border border-[rgba(49,245,212,0.18)] bg-[#111719] p-4 font-body text-[13px] leading-relaxed text-[#A8B3B0]">
+          This public case study is intentionally conservative. It focuses on information
+          architecture, workflow clarity, and product thinking while avoiding unverified metrics
+          or confidential product details.
+        </p>
+
+        <dl className="mt-10 grid gap-4 sm:grid-cols-2">
+          {META.map((item) => (
+            <div
+              key={item.label}
+              className="rounded-[6px] border border-[rgba(255,255,255,0.12)] bg-[#111719] p-4"
+            >
+              <dt className="font-ui text-[10px] uppercase tracking-[0.14em] text-[#31F5D4]">
+                {item.label}
+              </dt>
+              <dd className="mt-2 font-body text-[13px] leading-relaxed text-[#F4F7F6]">
+                {item.value}
+              </dd>
+            </div>
+          ))}
+        </dl>
+
+        <section className="case-study-section">
+          <h2 className="case-study-heading">Context</h2>
+          <p className="case-study-body">
+            Advanced accounting workflows can become difficult to understand when teams need to
+            classify, compare, and report on work across multiple dimensions. The design challenge
+            is not only to expose more structure, but to make that structure understandable and
+            useful.
+          </p>
+        </section>
+
+        <section className="case-study-section">
+          <h2 className="case-study-heading">
+            The challenge was making classification feel clear, not heavier.
+          </h2>
+          <p className="case-study-body">
+            As financial workflows become more dimensional, users need to understand what each
+            classification means, how it affects reporting, and how to act with confidence. The
+            experience needed to support structure without adding unnecessary cognitive load.
+          </p>
+        </section>
+
+        <section className="case-study-section">
+          <h2 className="case-study-heading">My role</h2>
+          <p className="case-study-body">
+            I contributed to the product experience by shaping workflow concepts, information
+            architecture, and interaction patterns for advanced accounting use cases. The work
+            focused on making dense classification and reporting workflows easier to understand,
+            navigate, and act on.
+          </p>
+        </section>
+
+        <section className="case-study-section">
+          <h2 className="case-study-heading">Design principles</h2>
+          <div className="mt-6 grid gap-4 sm:grid-cols-2">
+            {PRINCIPLES.map((p, i) => (
+              <div key={p.title} className="rounded-[6px] bg-[#111719] p-5">
+                <span className="font-display text-sm text-[#31F5D4]">
+                  {String(i + 1).padStart(2, "0")}
+                </span>
+                <h3 className="mt-2 font-ui text-sm text-[#F4F7F6]">{p.title}</h3>
+                <p className="mt-2 font-body text-[13px] leading-relaxed text-[#A8B3B0]">
+                  {p.copy}
+                </p>
+              </div>
+            ))}
+          </div>
+        </section>
+
+        <section className="case-study-section">
+          <h2 className="case-study-heading">Sanitized patterns</h2>
+          <div className="mt-6 grid gap-4 sm:grid-cols-2">
+            {PATTERNS.map((p) => (
+              <div
+                key={p.title}
+                className="rounded-[6px] border border-[rgba(255,255,255,0.08)] bg-[#0B0F10] p-5"
+              >
+                <h3 className="font-ui text-[11px] uppercase tracking-[0.12em] text-[#7CE7D6]">
+                  {p.title}
+                </h3>
+                <p className="mt-2 font-body text-[13px] leading-relaxed text-[#A8B3B0]">
+                  {p.copy}
+                </p>
+              </div>
+            ))}
+          </div>
+        </section>
+
+        <section className="case-study-section">
+          <h2 className="case-study-heading">Abstract visuals</h2>
+          <p className="case-study-body mb-6">
+            Synthetic diagrams showing classification and reporting thinking — generic labels only,
+            no confidential product UI.
+          </p>
+          <QboaCaseStudyVisuals />
+        </section>
+
+        <section className="case-study-section">
+          <h2 className="case-study-heading">What changed</h2>
+          <p className="case-study-body">
+            The work helped create clearer structure around advanced accounting workflows, making
+            it easier to reason about classification, reporting, and decision-making across complex
+            financial information.
+          </p>
+        </section>
+
+        <section className="case-study-section">
+          <h2 className="case-study-heading">Reflection</h2>
+          <p className="case-study-body">
+            The lesson from this work is that advanced systems do not become easier by hiding
+            complexity. They become easier when the underlying model is made visible, structured,
+            and connected to the decisions people need to make.
+          </p>
+        </section>
+
+        <footer className="mt-16 flex flex-wrap gap-4 border-t border-[rgba(255,255,255,0.12)] pt-10">
+          <Link href="/#work" className="case-study-cta case-study-cta--primary">
+            Back to selected work
+          </Link>
+          <Link href="/#contact" className="case-study-cta case-study-cta--secondary">
+            Get in touch
+          </Link>
+        </footer>
+      </article>
+    </main>
+  )
+}

--- a/app/work/quickbooks-dimensional-chart-of-accounts/page.tsx
+++ b/app/work/quickbooks-dimensional-chart-of-accounts/page.tsx
@@ -6,7 +6,7 @@ import QboaCaseStudyVisuals from "@/components/QboaCaseStudyVisuals"
 export const metadata: Metadata = {
   title: "Designing information architecture for advanced accounting workflows — Ardavan Mirhosseini",
   description:
-    "A public-safe case study shell about shaping advanced accounting workflows, dimensional classification, reporting clarity, and information architecture.",
+    "A public-safe case study about shaping advanced accounting workflows, dimensional classification, reporting clarity, and information architecture.",
 }
 
 const PRINCIPLES = [
@@ -57,7 +57,7 @@ const META = [
     label: "Output",
     value: "IA models, workflow concepts, product patterns, cross-functional artifacts",
   },
-  { label: "Status", value: "Public-safe case study foundation" },
+  { label: "Status", value: "Public-safe case study" },
 ]
 
 export default function QboaCaseStudyPage() {

--- a/components/IesCaseStudyVisuals.tsx
+++ b/components/IesCaseStudyVisuals.tsx
@@ -3,59 +3,113 @@
  * Generic labels and synthetic data only — no confidential UI.
  */
 
+import type { ReactNode } from "react"
+
+const STAGES = ["State", "Signal", "Evidence", "Decision", "Action"]
+
+function VisualBlurb({ children }: { children: ReactNode }) {
+  return <p className="ies-visual__blurb">{children}</p>
+}
+
 function SystemMap() {
-  const stages = ["State", "Signal", "Evidence", "Decision", "Action"]
   return (
     <figure className="ies-visual ies-visual--map" aria-labelledby="ies-visual-map-title">
       <figcaption id="ies-visual-map-title" className="ies-visual__caption">
         Complexity → clarity system map
       </figcaption>
+      <VisualBlurb>
+        A simplified model for turning ambiguous financial state into inspectable action.
+      </VisualBlurb>
       <svg
-        className="ies-visual__svg"
-        viewBox="0 0 640 80"
+        className="ies-visual__svg ies-visual__svg--map"
+        viewBox="0 0 640 120"
         role="img"
         aria-label="Flow from state to signal to evidence to decision to action"
       >
+        <defs>
+          <linearGradient id="ies-flow-grad" x1="0%" y1="0%" x2="100%" y2="0%">
+            <stop offset="0%" stopColor="#31F5D4" stopOpacity="0.2" />
+            <stop offset="50%" stopColor="#31F5D4" stopOpacity="0.8" />
+            <stop offset="100%" stopColor="#7CE7D6" stopOpacity="0.4" />
+          </linearGradient>
+        </defs>
         <line
-          x1="24"
-          y1="40"
-          x2="616"
-          y2="40"
-          stroke="#31F5D4"
-          strokeWidth="1.5"
-          strokeDasharray="6 8"
+          x1="32"
+          y1="56"
+          x2="608"
+          y2="56"
+          stroke="url(#ies-flow-grad)"
+          strokeWidth="2"
+          strokeDasharray="8 10"
           className="ies-flow-line"
         />
+        {STAGES.map((stage, i) => {
+          const x = 32 + i * 144
+          const isCheckpoint = stage === "Decision"
+          return (
+            <g key={stage}>
+              <circle
+                cx={x}
+                cy="56"
+                r={isCheckpoint ? 14 : 11}
+                fill="#0B0F10"
+                stroke={isCheckpoint ? "#FF7A66" : "#31F5D4"}
+                strokeWidth={isCheckpoint ? 1.5 : 1}
+                strokeOpacity={isCheckpoint ? 0.7 : 0.55}
+              />
+              <text
+                x={x}
+                y="60"
+                textAnchor="middle"
+                fill="#F4F7F6"
+                fontSize="9"
+                fontFamily="var(--font-mono), monospace"
+              >
+                {String(i + 1).padStart(2, "0")}
+              </text>
+              <text
+                x={x}
+                y="92"
+                textAnchor="middle"
+                fill="#A8B3B0"
+                fontSize="10"
+                fontFamily="var(--font-inter), system-ui, sans-serif"
+              >
+                {stage}
+              </text>
+            </g>
+          )
+        })}
       </svg>
-      <ol className="ies-visual__stages">
-        {stages.map((stage, i) => (
-          <li key={stage} className="ies-visual__stage">
-            <span className="ies-visual__stage-index">{String(i + 1).padStart(2, "0")}</span>
-            <span className="ies-visual__stage-label">{stage}</span>
-          </li>
-        ))}
-      </ol>
     </figure>
   )
 }
 
 function EvidenceRail() {
   const items = [
-    "Source context",
-    "Policy check",
-    "Materiality signal",
-    "Confidence note",
+    { label: "Source context", strength: 1 },
+    { label: "Policy check", strength: 0.85 },
+    { label: "Materiality signal", strength: 0.7 },
+    { label: "Confidence note", strength: 0.55 },
   ]
   return (
-    <figure className="ies-visual" aria-labelledby="ies-visual-rail-title">
+    <figure className="ies-visual ies-visual--rail" aria-labelledby="ies-visual-rail-title">
       <figcaption id="ies-visual-rail-title" className="ies-visual__caption">
         Evidence rail
       </figcaption>
+      <VisualBlurb>
+        Supporting context that helps users evaluate why a recommendation matters.
+      </VisualBlurb>
       <ul className="ies-visual__rail">
         {items.map((item) => (
-          <li key={item} className="ies-visual__rail-item">
+          <li key={item.label} className="ies-visual__rail-item">
             <span className="ies-visual__rail-dot" aria-hidden="true" />
-            {item}
+            <span className="ies-visual__rail-label">{item.label}</span>
+            <span
+              className="ies-visual__rail-bar"
+              style={{ width: `${item.strength * 100}%` }}
+              aria-hidden="true"
+            />
           </li>
         ))}
       </ul>
@@ -65,25 +119,60 @@ function EvidenceRail() {
 
 function DecisionPacket() {
   const fields = [
-    { label: "Recommendation", value: "Review classification variance" },
+    { label: "Recommendation", value: "Review classification variance", highlight: true },
     { label: "Evidence", value: "3 supporting signals attached" },
     { label: "Risk", value: "Medium — requires human review" },
     { label: "Human review", value: "Pending approval" },
     { label: "Approval state", value: "Awaiting decision" },
   ]
   return (
-    <figure className="ies-visual" aria-labelledby="ies-visual-packet-title">
+    <figure className="ies-visual ies-visual--packet" aria-labelledby="ies-visual-packet-title">
       <figcaption id="ies-visual-packet-title" className="ies-visual__caption">
         Decision packet
       </figcaption>
+      <VisualBlurb>
+        A structured object that brings together recommendation, rationale, risk, and next step.
+      </VisualBlurb>
       <dl className="ies-visual__packet">
         {fields.map((f) => (
-          <div key={f.label} className="ies-visual__packet-row">
+          <div
+            key={f.label}
+            className={`ies-visual__packet-row${f.highlight ? " ies-visual__packet-row--highlight" : ""}`}
+          >
             <dt>{f.label}</dt>
             <dd>{f.value}</dd>
           </div>
         ))}
       </dl>
+    </figure>
+  )
+}
+
+function HumanJudgmentCheckpoint() {
+  return (
+    <figure className="ies-visual ies-visual--checkpoint" aria-labelledby="ies-visual-checkpoint-title">
+      <figcaption id="ies-visual-checkpoint-title" className="ies-visual__caption">
+        Human judgment checkpoint
+      </figcaption>
+      <VisualBlurb>
+        A deliberate pause before meaningful action, preserving review and control.
+      </VisualBlurb>
+      <div className="ies-visual__checkpoint" aria-hidden="true">
+        <div className="ies-visual__checkpoint-lane">
+          <span className="ies-visual__checkpoint-node">Signal</span>
+          <span className="ies-visual__checkpoint-arrow">→</span>
+          <span className="ies-visual__checkpoint-gate">
+            <span className="ies-visual__checkpoint-gate-label">Review</span>
+          </span>
+          <span className="ies-visual__checkpoint-arrow">→</span>
+          <span className="ies-visual__checkpoint-node">Action</span>
+        </div>
+        <ul className="ies-visual__checkpoint-actions">
+          <li>Confirm</li>
+          <li>Escalate</li>
+          <li>Defer</li>
+        </ul>
+      </div>
     </figure>
   )
 }
@@ -96,10 +185,13 @@ function ApprovalReceipt() {
     { label: "Follow-up", value: "Audit trail available" },
   ]
   return (
-    <figure className="ies-visual" aria-labelledby="ies-visual-receipt-title">
+    <figure className="ies-visual ies-visual--receipt" aria-labelledby="ies-visual-receipt-title">
       <figcaption id="ies-visual-receipt-title" className="ies-visual__caption">
         Approval receipt
       </figcaption>
+      <VisualBlurb>
+        A closing artifact that records what changed and where it can be reviewed.
+      </VisualBlurb>
       <dl className="ies-visual__receipt">
         {fields.map((f) => (
           <div key={f.label} className="ies-visual__receipt-row">
@@ -108,6 +200,9 @@ function ApprovalReceipt() {
           </div>
         ))}
       </dl>
+      <div className="ies-visual__receipt-stamp" aria-hidden="true">
+        Recorded
+      </div>
     </figure>
   )
 }
@@ -116,6 +211,7 @@ export default function IesCaseStudyVisuals() {
   return (
     <div className="ies-visuals-grid">
       <SystemMap />
+      <HumanJudgmentCheckpoint />
       <div className="ies-visuals-grid__pair">
         <EvidenceRail />
         <DecisionPacket />

--- a/components/ProjectCardVisual.tsx
+++ b/components/ProjectCardVisual.tsx
@@ -1,0 +1,93 @@
+/**
+ * Abstract mini-visuals for homepage Selected Work cards.
+ * Decorative only — generic synthetic patterns, no product UI.
+ */
+
+type ProjectCardVisualVariant = "ies" | "qboa" | "community"
+
+type ProjectCardVisualProps = {
+  variant: ProjectCardVisualVariant
+}
+
+export default function ProjectCardVisual({ variant }: ProjectCardVisualProps) {
+  if (variant === "ies") {
+    return (
+      <div className="project-card-visual" aria-hidden="true">
+        <svg className="project-card-visual__svg" viewBox="0 0 280 72" fill="none">
+          <line
+            x1="12"
+            y1="36"
+            x2="268"
+            y2="36"
+            stroke="rgba(49, 245, 212, 0.35)"
+            strokeWidth="1"
+            strokeDasharray="4 6"
+          />
+          {[
+            { x: 28, label: "S" },
+            { x: 84, label: "E" },
+            { x: 140, label: "D" },
+            { x: 196, label: "A" },
+            { x: 252, label: "→" },
+          ].map((node) => (
+            <g key={node.x}>
+              <circle cx={node.x} cy="36" r="10" fill="#0B0F10" stroke="rgba(49, 245, 212, 0.5)" strokeWidth="1" />
+              <text
+                x={node.x}
+                y="40"
+                textAnchor="middle"
+                fill="#7CE7D6"
+                fontSize="8"
+                fontFamily="monospace"
+              >
+                {node.label}
+              </text>
+            </g>
+          ))}
+        </svg>
+      </div>
+    )
+  }
+
+  if (variant === "qboa") {
+    const cells = ["D1", "D2", "D3", "Cat", "Rpt", "View"]
+    return (
+      <div className="project-card-visual" aria-hidden="true">
+        <div className="project-card-visual__grid">
+          {cells.map((cell) => (
+            <span key={cell} className="project-card-visual__grid-cell">
+              {cell}
+            </span>
+          ))}
+        </div>
+      </div>
+    )
+  }
+
+  return (
+    <div className="project-card-visual" aria-hidden="true">
+      <svg className="project-card-visual__svg" viewBox="0 0 280 72" fill="none">
+        {[
+          { cx: 70, cy: 28 },
+          { cx: 140, cy: 44 },
+          { cx: 210, cy: 24 },
+          { cx: 100, cy: 52 },
+          { cx: 180, cy: 56 },
+        ].map((node, i) => (
+          <circle
+            key={i}
+            cx={node.cx}
+            cy={node.cy}
+            r="5"
+            fill="rgba(49, 245, 212, 0.25)"
+            stroke="rgba(49, 245, 212, 0.45)"
+            strokeWidth="1"
+          />
+        ))}
+        <line x1="70" y1="28" x2="140" y2="44" stroke="rgba(255,255,255,0.12)" strokeWidth="1" />
+        <line x1="140" y1="44" x2="210" y2="24" stroke="rgba(255,255,255,0.12)" strokeWidth="1" />
+        <line x1="100" y1="52" x2="180" y2="56" stroke="rgba(255,255,255,0.12)" strokeWidth="1" />
+      </svg>
+    </div>
+  )
+}

--- a/components/QboaCaseStudyVisuals.tsx
+++ b/components/QboaCaseStudyVisuals.tsx
@@ -1,0 +1,162 @@
+/**
+ * Sanitized abstract visuals for the QBOA public case study.
+ * Generic labels and synthetic data only — no confidential UI.
+ */
+
+import type { ReactNode } from "react"
+
+function VisualBlurb({ children }: { children: ReactNode }) {
+  return <p className="case-visual__blurb">{children}</p>
+}
+
+function ClassificationGrid() {
+  const rows = [
+    ["Dimension A", "Category 1", "Report view"],
+    ["Dimension B", "Category 2", "Report view"],
+    ["Dimension C", "Category 3", "Report view"],
+  ]
+  return (
+    <figure className="case-visual" aria-labelledby="qboa-grid-title">
+      <figcaption id="qboa-grid-title" className="case-visual__caption">
+        Dimensional classification grid
+      </figcaption>
+      <VisualBlurb>
+        A structured view that helps teams see how classifications relate across dimensions.
+      </VisualBlurb>
+      <div className="qboa-visual__grid" role="img" aria-label="Abstract dimensional classification grid">
+        <div className="qboa-visual__grid-header">
+          <span>Dimension</span>
+          <span>Category</span>
+          <span>Report view</span>
+        </div>
+        {rows.map((row, i) => (
+          <div key={i} className="qboa-visual__grid-row">
+            {row.map((cell) => (
+              <span key={cell} className="qboa-visual__grid-cell">
+                {cell}
+              </span>
+            ))}
+          </div>
+        ))}
+      </div>
+    </figure>
+  )
+}
+
+function ReportingContextLayer() {
+  const layers = ["Account structure", "Classification", "Report context", "Decision view"]
+  return (
+    <figure className="case-visual" aria-labelledby="qboa-context-title">
+      <figcaption id="qboa-context-title" className="case-visual__caption">
+        Reporting context layer
+      </figcaption>
+      <VisualBlurb>
+        Layers that connect classification choices to reporting and decision context.
+      </VisualBlurb>
+      <ul className="qboa-visual__layers">
+        {layers.map((layer, i) => (
+          <li key={layer} className="qboa-visual__layer" style={{ marginLeft: `${i * 12}px` }}>
+            <span className="qboa-visual__layer-index">{String(i + 1).padStart(2, "0")}</span>
+            {layer}
+          </li>
+        ))}
+      </ul>
+    </figure>
+  )
+}
+
+function AccountStructureModel() {
+  return (
+    <figure className="case-visual" aria-labelledby="qboa-structure-title">
+      <figcaption id="qboa-structure-title" className="case-visual__caption">
+        Account structure model
+      </figcaption>
+      <VisualBlurb>
+        An abstract model showing how account hierarchy supports classification clarity.
+      </VisualBlurb>
+      <svg className="case-visual__svg" viewBox="0 0 320 140" role="img" aria-label="Abstract account structure tree">
+        <line x1="160" y1="24" x2="80" y2="72" stroke="rgba(49,245,212,0.35)" strokeWidth="1" />
+        <line x1="160" y1="24" x2="240" y2="72" stroke="rgba(49,245,212,0.35)" strokeWidth="1" />
+        <line x1="80" y1="72" x2="48" y2="116" stroke="rgba(255,255,255,0.15)" strokeWidth="1" />
+        <line x1="80" y1="72" x2="112" y2="116" stroke="rgba(255,255,255,0.15)" strokeWidth="1" />
+        <line x1="240" y1="72" x2="208" y2="116" stroke="rgba(255,255,255,0.15)" strokeWidth="1" />
+        <line x1="240" y1="72" x2="272" y2="116" stroke="rgba(255,255,255,0.15)" strokeWidth="1" />
+        {[
+          { x: 160, y: 24, label: "Root" },
+          { x: 80, y: 72, label: "Branch" },
+          { x: 240, y: 72, label: "Branch" },
+          { x: 48, y: 116, label: "Leaf" },
+          { x: 112, y: 116, label: "Leaf" },
+          { x: 208, y: 116, label: "Leaf" },
+          { x: 272, y: 116, label: "Leaf" },
+        ].map((node) => (
+          <g key={`${node.x}-${node.y}`}>
+            <rect
+              x={node.x - 28}
+              y={node.y - 10}
+              width="56"
+              height="20"
+              rx="4"
+              fill="#0B0F10"
+              stroke="rgba(49,245,212,0.4)"
+              strokeWidth="1"
+            />
+            <text
+              x={node.x}
+              y={node.y + 4}
+              textAnchor="middle"
+              fill="#A8B3B0"
+              fontSize="9"
+              fontFamily="var(--font-inter), system-ui, sans-serif"
+            >
+              {node.label}
+            </text>
+          </g>
+        ))}
+      </svg>
+    </figure>
+  )
+}
+
+function ReviewConfirmation() {
+  const fields = [
+    { label: "Classification", value: "Synthetic category assignment" },
+    { label: "Decision context", value: "Reporting impact preview" },
+    { label: "Review state", value: "Pending confirmation" },
+  ]
+  return (
+    <figure className="case-visual" aria-labelledby="qboa-review-title">
+      <figcaption id="qboa-review-title" className="case-visual__caption">
+        Review and confirmation moment
+      </figcaption>
+      <VisualBlurb>
+        A deliberate step where users confirm classification before it affects reporting.
+      </VisualBlurb>
+      <dl className="case-visual__fields">
+        {fields.map((f) => (
+          <div key={f.label} className="case-visual__field-row">
+            <dt>{f.label}</dt>
+            <dd>{f.value}</dd>
+          </div>
+        ))}
+      </dl>
+      <div className="qboa-visual__review-actions" aria-hidden="true">
+        <span className="qboa-visual__review-btn qboa-visual__review-btn--primary">Confirm</span>
+        <span className="qboa-visual__review-btn">Adjust</span>
+      </div>
+    </figure>
+  )
+}
+
+export default function QboaCaseStudyVisuals() {
+  return (
+    <div className="case-visuals-grid">
+      <ClassificationGrid />
+      <div className="case-visuals-grid__pair">
+        <ReportingContextLayer />
+        <AccountStructureModel />
+      </div>
+      <ReviewConfirmation />
+    </div>
+  )
+}

--- a/content/ask-ardavan.ts
+++ b/content/ask-ardavan.ts
@@ -43,6 +43,12 @@ export const ASK_ARDAVAN_PROMPTS: AskArdavanPrompt[] = [
     assistantTitle: "Where to start",
     answer:
       "Start with Intuit Enterprise Suite if you want to understand my AI-native enterprise product work. Look at QuickBooks Online Advanced for advanced accounting IA, and Iranians Who Design for my founder/community platform work.",
+    links: [
+      {
+        label: "View the public-safe QBOA case study",
+        href: "/work/quickbooks-dimensional-chart-of-accounts",
+      },
+    ],
   },
   {
     id: "ai-native",

--- a/docs/sot/changelog.md
+++ b/docs/sot/changelog.md
@@ -8,6 +8,7 @@
 - Linked homepage QBOA card and Ask Ardavan start prompt to QBOA case study
 - Added project-card abstract thumbnails (IES, QBOA, Iranians Who Design)
 - Archived duplicate local résumé PDFs outside repo (`../portfolio-local-archive/`)
+- Polished QBOA public page status wording (removed “foundation” / “shell” from live copy)
 - Continued claims guardrails in portfolio-claims-log.md
 
 ## 2026-07-10 — Portfolio Sprint 2.1 — Legacy Claims Cleanup

--- a/docs/sot/changelog.md
+++ b/docs/sot/changelog.md
@@ -1,5 +1,15 @@
 # Portfolio Changelog (Sprint Docs)
 
+## 2026-07-10 — Portfolio Sprint 3 — IES visual polish + QBOA case study foundation
+
+- Polished IES abstract visuals: system map, human judgment checkpoint, captions, visual hierarchy
+- Added QBOA public-safe case study route at `/work/quickbooks-dimensional-chart-of-accounts`
+- Added QBOA sanitized visuals and SOT
+- Linked homepage QBOA card and Ask Ardavan start prompt to QBOA case study
+- Added project-card abstract thumbnails (IES, QBOA, Iranians Who Design)
+- Archived duplicate local résumé PDFs outside repo (`../portfolio-local-archive/`)
+- Continued claims guardrails in portfolio-claims-log.md
+
 ## 2026-07-10 — Portfolio Sprint 2.1 — Legacy Claims Cleanup
 
 - Quarantined unverified metrics and risky verbs from legacy unused components (`projects.tsx`, `about.tsx`, `hero.tsx`, `contact.tsx`)

--- a/docs/sot/changelog.md
+++ b/docs/sot/changelog.md
@@ -1,5 +1,13 @@
 # Portfolio Changelog (Sprint Docs)
 
+## 2026-07-10 — Sprint documentation update — Executive storytelling and future prototypes
+
+- Added `executive-storytelling-and-future-prototypes-sot.md` for future-state IES exploration, adjacent product prototype adaptation, and leadership/investor-facing demo storytelling
+- Captured this work as future portfolio opportunity, not public copy
+- Updated portfolio roadmap, claims log, IES case study SOT, and sanitized visual plan
+- Marked sensitive details as PRIVATE_CONTEXT / VERIFY
+- Preserved guardrails around internal names, executive audiences, event names, prototype details, and unverified outcomes
+
 ## 2026-07-10 — Portfolio Sprint 3 — IES visual polish + QBOA case study foundation
 
 - Polished IES abstract visuals: system map, human judgment checkpoint, captions, visual hierarchy

--- a/docs/sot/executive-storytelling-and-future-prototypes-sot.md
+++ b/docs/sot/executive-storytelling-and-future-prototypes-sot.md
@@ -1,0 +1,80 @@
+# Executive Storytelling and Future-State Prototypes SOT — Public-Safe Backlog
+
+Version: 1.0  
+Last updated: 2026-07-10  
+Status: PRIVATE_CONTEXT / VERIFY — not for public publication until approved
+
+## Purpose
+
+Capture private/contextual evidence for future portfolio improvements around executive storytelling, future-state IES exploration, adjacent product prototype work, and investor-facing demo craft.
+
+## Public-safe summary
+
+Ardavan has private-context experience contributing to future-state enterprise product explorations, adapting AI-native experience concepts across adjacent product areas, creating executive-facing functional prototypes, and shaping leadership/investor-facing demo narratives. This material is strategically important for the portfolio, but should be handled carefully because exact team names, product acronyms, executive audiences, and demo contexts may be sensitive.
+
+## 1. Why this matters
+
+This body of work strengthens the portfolio narrative beyond screen-level design. It shows Ardavan operating in ambiguous, high-stakes product moments where teams need frameworks, prototypes, and stories that make future product direction understandable and credible.
+
+## 2. Public-safe themes
+
+- Future-state enterprise product strategy
+- AI-native product thinking
+- Framework transfer across related product areas
+- Functional prototyping for senior leadership review
+- Executive storytelling
+- Investor-facing demo craft
+- Leadership alignment
+- Making complex capabilities tangible
+- Translating ambiguity into product narratives
+- Evidence-backed visual storytelling
+
+## 3. Potential future portfolio treatments
+
+- IES case study expansion: future-state product exploration
+- Private interview walkthrough: executive prototype and demo storytelling
+- Public-safe proof section: “What teams bring me in for”
+- Résumé bullet update after verification
+- Ask Ardavan V1.5 prompt about executive storytelling
+- Sanitized visual: prototype-to-demo narrative arc
+- Sanitized visual: framework transfer map
+- Sanitized visual: leadership demo storyboard
+
+## 4. Do not publish without approval
+
+- Exact internal team names
+- Adjacent product acronyms
+- Names of executives or reviewers
+- Named senior-leadership review context (e.g. specific executive titles or individuals)
+- Named investor-facing leadership event titles
+- Raw recognition screenshots
+- Private Slack messages or quotes
+- Internal deck screenshots
+- Internal prototype screenshots
+- Roadmap details
+- Exact outcomes or decisions
+- Claims that concepts shipped, launched, or were adopted
+
+## 5. Open verification questions
+
+- Can the future-state IES exploration team be named publicly?
+- Can the adjacent product area be named publicly?
+- Can the executive prototype be described publicly?
+- Can the demo audience be described as senior leadership, or must it remain generic?
+- Can the investor-facing leadership event be named publicly?
+- Which artifacts did Ardavan personally create?
+- Which artifacts can be sanitized and shown?
+- What date range should be used?
+- What public role wording is approved?
+- Were there any outcomes that can be verified without overclaiming?
+
+## 6. Safe public wording candidates
+
+- “Contributed to future-state enterprise product explorations by translating AI-native concepts into functional prototypes and leadership-ready narratives.”
+- “Adapted AI-native experience concepts across adjacent enterprise product contexts through prototype-driven storytelling.”
+- “Trusted to shape executive- and investor-facing demo narratives that made complex product capabilities clear, tangible, and credible.”
+- “Created functional prototypes and visual narratives that helped senior stakeholders evaluate future product direction.”
+
+## 7. Claims status
+
+All items in this SOT are **PRIVATE_CONTEXT / VERIFY** until Ardavan approves public wording, naming boundaries, and artifact publication scope.

--- a/docs/sot/ies-case-study-sot.md
+++ b/docs/sot/ies-case-study-sot.md
@@ -1,7 +1,7 @@
 # IES Case Study SOT — Public-Safe Version
 
-Version: 1.0  
-Last updated: 2026-07-09  
+Version: 1.1  
+Last updated: 2026-07-10  
 Status: Public-safe case study
 
 ## Public case study route
@@ -63,3 +63,16 @@ Helped define and communicate AI-native product direction for complex enterprise
 - Which sanitized artifacts Ardavan personally wants to claim
 - Whether “Intuit Enterprise Suite” can appear in the public case study title
 - Whether any outcomes can be verified later
+
+## Future expansion opportunities
+
+Not part of the current public case study until wording, naming, artifacts, and publication boundaries are approved.
+
+- Future-state IES exploration narrative
+- Framework transfer to adjacent enterprise product contexts
+- Executive-facing prototype work
+- Leadership/investor demo storytelling
+- Private interview walkthrough
+- Sanitized artifact set for prototype-to-demo storytelling
+
+See also: `docs/sot/executive-storytelling-and-future-prototypes-sot.md`

--- a/docs/sot/portfolio-claims-log.md
+++ b/docs/sot/portfolio-claims-log.md
@@ -1,6 +1,6 @@
 # Portfolio Claims Log
 
-Version: 1.2  
+Version: 1.3  
 Last updated: 2026-07-10  
 Status: Public-safe
 
@@ -22,3 +22,8 @@ Status: Public-safe
 | QBOA launch, adoption, or revenue impact. | DO_NOT_PUBLISH | Do not use. | Not verified. |
 | QBOA exact role, dates, and artifact ownership. | VERIFY | Confirm before expanding case study or résumé. | Track verification here only. |
 | Résumé employment dates (Intuit, Iranians Who Design, earlier roles). | VERIFY | Omit or confirm exact dates before next résumé PDF update. | Verification tracked here only — not in `content/resume.md`. |
+| Ardavan contributes to future-state IES exploration. | PRIVATE_CONTEXT / VERIFY | Contributed to future-state enterprise product explorations. | Do not name internal team or exact initiative until approved. |
+| Ardavan adapted IES AI-native concepts to an adjacent product area. | PRIVATE_CONTEXT / VERIFY | Adapted AI-native experience concepts across adjacent enterprise product contexts. | Do not name the adjacent product acronym until approved. |
+| Ardavan created a functioning prototype for senior leadership review. | PRIVATE_CONTEXT / VERIFY | Created executive-facing functional prototypes to help senior stakeholders evaluate future product direction. | Do not name executive reviewers, demo owner, leadership context, or prototype details until approved. |
+| Ardavan contributes to investor-facing leadership demos. | PRIVATE_CONTEXT / VERIFY | Trusted to shape executive- and investor-facing demo narratives that make complex product capabilities tangible. | Verify whether the event name and leadership/investor audience can be named publicly. |
+| Ardavan’s portfolio can emphasize executive product storytelling. | PUBLIC_SAFE when abstracted | Making complex product capabilities tangible through prototypes, narratives, and evidence-backed visual storytelling. | Supported by recognition themes; do not publish raw screenshots or private quotes. |

--- a/docs/sot/portfolio-claims-log.md
+++ b/docs/sot/portfolio-claims-log.md
@@ -1,6 +1,6 @@
 # Portfolio Claims Log
 
-Version: 1.1  
+Version: 1.2  
 Last updated: 2026-07-10  
 Status: Public-safe
 
@@ -16,5 +16,9 @@ Status: Public-safe
 | Internal source-pack terminology and prototype names. | DO_NOT_PUBLISH | Do not use. | Keep outside public repo unless explicitly approved. |
 | Legacy `components/projects.tsx` TurboTax/Mint/QB metrics (40%, 80%, 150%, 50M+ users, Lead roles). | DO_NOT_PUBLISH | Do not use. | Removed in Sprint 2.1; file is legacy placeholder only. See `legacy-portfolio-components.md`. |
 | Legacy `components/about.tsx` impact metrics (50M+ users, 40% efficiency). | DO_NOT_PUBLISH | Do not use. | Removed in Sprint 2.1; file is legacy placeholder only. |
-| QBOA ~20% engagement lift. | VERIFY | Do not use until Ardavan verifies. | Referenced in SOT-01/SOT-11; never publish without confirmation. |
+| QBOA ~20% engagement lift. | VERIFY / DO_NOT_PUBLISH | Do not use until Ardavan verifies. | Referenced in SOT-01/SOT-11; never publish without confirmation. |
+| QBOA ~26% engagement claim. | DO_NOT_PUBLISH | Do not use. | Unverified; do not publish. |
+| QBOA case study qualitative claims (IA, classification, reporting clarity). | PUBLIC_SAFE (conservative) | Shaped advanced accounting workflows that help teams understand multi-dimensional classification, reporting, and decision-making inside a complex financial product. | Use “shaped” and “contributed to,” not “led” or “launched.” |
+| QBOA launch, adoption, or revenue impact. | DO_NOT_PUBLISH | Do not use. | Not verified. |
+| QBOA exact role, dates, and artifact ownership. | VERIFY | Confirm before expanding case study or résumé. | Track verification here only. |
 | Résumé employment dates (Intuit, Iranians Who Design, earlier roles). | VERIFY | Omit or confirm exact dates before next résumé PDF update. | Verification tracked here only — not in `content/resume.md`. |

--- a/docs/sot/portfolio-roadmap.md
+++ b/docs/sot/portfolio-roadmap.md
@@ -1,6 +1,6 @@
 # Portfolio Roadmap
 
-Version: 1.1  
+Version: 1.2  
 Last updated: 2026-07-10  
 Status: Public-safe
 
@@ -29,6 +29,7 @@ Status: Public-safe
 
 ### P2 — Expand portfolio depth
 
+- Executive storytelling and future-state prototype narrative (see `executive-storytelling-and-future-prototypes-sot.md`)
 - Ask Ardavan V1.5 suggested next prompts
 - Add “What teams bring me in for” proof section
 - Deeper private interview walkthrough for sensitive work (outside public repo if needed)
@@ -58,6 +59,25 @@ Portfolio Sprint 3 — IES visual polish + QBOA case study foundation
 - Proof section expansion
 - OG/social preview assets
 - IES deeper visual narrative
+
+### P2 — Executive storytelling and future-state prototype narrative
+
+Document and later develop a public-safe portfolio treatment around future-state IES exploration, cross-product concept adaptation, executive-facing functional prototypes, and investor-facing leadership demos.
+
+Reference: `docs/sot/executive-storytelling-and-future-prototypes-sot.md`
+
+## Future sprint candidate — Sprint 4 or later
+
+**Executive Storytelling Proof Layer**
+
+Potential deliverables:
+
+- “What teams bring me in for” homepage section
+- IES case study expansion around future-state exploration
+- Private interview walkthrough for executive prototype work
+- Sanitized visual storytelling artifacts
+- Résumé bullet update after verification
+- Ask Ardavan V1.5 prompt about executive storytelling
 
 ## Out of scope
 

--- a/docs/sot/portfolio-roadmap.md
+++ b/docs/sot/portfolio-roadmap.md
@@ -1,7 +1,7 @@
 # Portfolio Roadmap
 
-Version: 1.0  
-Last updated: 2026-07-09  
+Version: 1.1  
+Last updated: 2026-07-10  
 Status: Public-safe
 
 ## Current status
@@ -9,7 +9,9 @@ Status: Public-safe
 - Homepage is live with AI-native legibility positioning
 - Résumé PDF is live at `/resume-ardavan-mir.pdf`
 - Static guided Ask Ardavan chat is live
-- IES and QBOA cards still need case study depth (IES foundation in progress)
+- IES public-safe case study is live at `/work/intuit-enterprise-suite`
+- QBOA public-safe case study foundation is in progress (Sprint 3)
+- Legacy claims cleanup merged (Sprint 2.1)
 
 ## Priority order
 
@@ -18,19 +20,18 @@ Status: Public-safe
 - Preserve accessibility, mobile responsiveness, static export, CNAME, and deployment config
 - Avoid confidential content and unverified claims
 
-### P1 — IES public case study
+### P1 — Case study depth
 
-- Build NDA-safe IES public case study
-- Create sanitized visuals for IES
-- Link homepage and Ask Ardavan to the IES case study
-- Create deeper private interview walkthrough later, outside public repo if sensitive
+- Polish IES sanitized visuals
+- Build QBOA public case study foundation
+- Link homepage and Ask Ardavan to QBOA case study
+- Add project-card abstract thumbnails
 
 ### P2 — Expand portfolio depth
 
-- Create QBOA / Dimensional Chart of Accounts case study shell
-- Add project-card abstract visuals
-- Add Ask Ardavan V1.5 suggested next prompts
+- Ask Ardavan V1.5 suggested next prompts
 - Add “What teams bring me in for” proof section
+- Deeper private interview walkthrough for sensitive work (outside public repo if needed)
 
 ### P3 — Polish and legacy work
 
@@ -38,30 +39,30 @@ Status: Public-safe
 - Add OG/social preview polish
 - Add older projects only after scope and claims are verified
 
-## Sprint 2 scope
+## Sprint 3 scope
 
-Portfolio Sprint 2 — IES Case Study Foundation
+Portfolio Sprint 3 — IES visual polish + QBOA case study foundation
 
-- SOT docs (public-safe)
-- IES public case study route at `/work/intuit-enterprise-suite`
-- Sanitized abstract visuals
-- Homepage IES link
-- Ask Ardavan IES link
-- Build QA
+- IES visual polish (human judgment checkpoint, captions, hierarchy)
+- QBOA case study route at `/work/quickbooks-dimensional-chart-of-accounts`
+- QBOA sanitized visuals
+- Homepage QBOA link
+- Ask Ardavan QBOA link (where supported)
+- Project-card abstract thumbnails
+- Updated SOT docs and claims log
 
 ## Later backlog
 
-- IES sanitized visual polish
-- QBOA case study shell
+- QBOA visual polish and verified artifacts
 - Ask Ardavan suggested next prompts
 - Proof section expansion
 - OG/social preview assets
+- IES deeper visual narrative
 
 ## Out of scope
 
 - Real AI chat
 - Backend/API routes
 - Confidential materials in repo
-- QBOA full case study (this sprint)
 - Unverified metrics
 - Production merge without review

--- a/docs/sot/qboa-case-study-sot.md
+++ b/docs/sot/qboa-case-study-sot.md
@@ -1,0 +1,62 @@
+# QBOA Case Study SOT — Public-Safe Version
+
+Version: 1.0  
+Last updated: 2026-07-10  
+Status: Public-safe case study foundation
+
+## Public case study route
+
+`/work/quickbooks-dimensional-chart-of-accounts`
+
+## Working title
+
+Designing information architecture for advanced accounting workflows
+
+## Public-safe one-liner
+
+Shaped advanced accounting workflows that help teams understand multi-dimensional classification, reporting, and decision-making inside a complex financial product.
+
+## Case study sections
+
+1. Context
+2. The challenge
+3. My role
+4. Design principles
+5. Sanitized patterns
+6. Abstract visuals
+7. What changed
+8. Reflection
+
+## Approved public-safe themes
+
+- Advanced accounting
+- Dimensional classification
+- Information architecture
+- Reporting clarity
+- Workflow structure
+- Decision-making clarity
+- Scalable product patterns
+- Cross-functional collaboration
+
+## Do not publish
+
+- Unverified metrics
+- “20%” or “26%” engagement claims
+- Adoption lift
+- Revenue impact
+- Launch claims
+- Unsupported “led” claims
+- Confidential screenshots
+- Internal roadmap details
+- Customer names
+- Internal product screenshots
+
+## Open verification questions
+
+- Exact product naming: Classes, Dimensional Chart of Accounts, or both?
+- Exact date range
+- Exact title/role at the time
+- Whether any metrics can be verified
+- Which artifacts can be shown publicly
+- Whether any product screenshots are approved
+- Whether this should be a full case study or shorter case study

--- a/docs/sot/qboa-case-study-sot.md
+++ b/docs/sot/qboa-case-study-sot.md
@@ -2,7 +2,7 @@
 
 Version: 1.0  
 Last updated: 2026-07-10  
-Status: Public-safe case study foundation
+Status: Public-safe case study
 
 ## Public case study route
 

--- a/docs/sot/sanitized-visual-plan.md
+++ b/docs/sot/sanitized-visual-plan.md
@@ -1,6 +1,6 @@
 # Sanitized Visual Plan
 
-Version: 1.1  
+Version: 1.2  
 Last updated: 2026-07-10  
 Status: Public-safe
 
@@ -49,3 +49,29 @@ Implemented in `components/ProjectCardVisual.tsx` (decorative, aria-hidden).
 - IES: `components/IesCaseStudyVisuals.tsx` — polished Sprint 3 with captions and human judgment checkpoint
 - QBOA: `components/QboaCaseStudyVisuals.tsx` — abstract classification and reporting diagrams
 - Homepage cards: `components/ProjectCardVisual.tsx`
+
+## Future visual concepts — Executive storytelling / future prototypes
+
+Not yet implemented. See `docs/sot/executive-storytelling-and-future-prototypes-sot.md`.
+
+1. **Framework transfer map**  
+   Shows how a core AI-native concept can be adapted from one enterprise context to another without exposing product specifics.
+
+2. **Prototype-to-demo storyboard**  
+   Shows how a future-state product concept becomes a leadership-ready narrative.
+
+3. **Executive alignment map**  
+   Shows how ambiguity, evidence, prototype, narrative, and decision come together.
+
+4. **Investor narrative layer**  
+   Shows how complex capabilities can be translated into a clear, credible story for external-facing leadership moments.
+
+### Rules for future executive visuals
+
+- Use synthetic labels only
+- Do not use real executive names
+- Do not use internal product names or acronyms
+- Do not use confidential screenshots
+- Do not use real deck screenshots
+- Do not use real demo scripts
+- Do not imply launch, adoption, or business impact

--- a/docs/sot/sanitized-visual-plan.md
+++ b/docs/sot/sanitized-visual-plan.md
@@ -1,7 +1,7 @@
 # Sanitized Visual Plan
 
-Version: 1.0  
-Last updated: 2026-07-09  
+Version: 1.1  
+Last updated: 2026-07-10  
 Status: Public-safe
 
 ## Purpose
@@ -17,6 +17,21 @@ Create case study visuals that show thinking and craft without exposing confiden
 5. Human judgment checkpoint
 6. Approval receipt
 
+## Visuals to build for QBOA V1
+
+1. Dimensional classification grid
+2. Reporting context layer
+3. Account structure model
+4. Review and confirmation moment
+
+## Homepage project-card thumbnails
+
+1. IES — abstract decision flow
+2. QBOA — dimensional classification grid
+3. Iranians Who Design — community constellation
+
+Implemented in `components/ProjectCardVisual.tsx` (decorative, aria-hidden).
+
 ## Rules
 
 - Use abstract diagrams
@@ -31,4 +46,6 @@ Create case study visuals that show thinking and craft without exposing confiden
 
 ## V1 implementation
 
-Implemented in `components/IesCaseStudyVisuals.tsx` as abstract SVG/HTML diagrams with generic synthetic labels.
+- IES: `components/IesCaseStudyVisuals.tsx` — polished Sprint 3 with captions and human judgment checkpoint
+- QBOA: `components/QboaCaseStudyVisuals.tsx` — abstract classification and reporting diagrams
+- Homepage cards: `components/ProjectCardVisual.tsx`


### PR DESCRIPTION
## Summary
Adds a public-safe QBOA / Dimensional Chart of Accounts case study foundation and improves sanitized IES visual storytelling.

## Included
- QBOA public-safe case study route
- QBOA sanitized visuals
- IES visual polish
- Homepage QBOA case study link
- Ask Ardavan QBOA link on start prompt
- Project-card abstract thumbnails
- Updated SOT docs and claims log

## Safety
- No confidential screenshots
- No customer names
- No private quotes
- No internal roadmap details
- No unverified metrics
- No launch/adoption/revenue claims
- No backend/API/OpenAI changes
- No new dependencies

## QA
- pnpm build passed

Made with [Cursor](https://cursor.com)