### PR TITLE
Add executive storytelling proof layer

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -238,6 +238,77 @@ img {
   animation: softRise 0.7s cubic-bezier(0.4, 0, 0.2, 1) both;
 }
 
+/* Homepage proof layer — executive storytelling */
+.proof-layer__card {
+  border-radius: 6px;
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  background: #111719;
+  padding: 1.75rem;
+}
+
+.proof-layer__arc {
+  margin-top: 2rem;
+  overflow-x: auto;
+  -webkit-overflow-scrolling: touch;
+}
+
+.proof-layer__arc-track {
+  display: flex;
+  align-items: flex-start;
+  gap: 0;
+  min-width: min(100%, 36rem);
+  padding: 0.5rem 0;
+}
+
+.proof-layer__arc-step {
+  position: relative;
+  display: flex;
+  flex: 1;
+  flex-direction: column;
+  align-items: center;
+  min-width: 4.5rem;
+}
+
+.proof-layer__arc-node {
+  display: block;
+  width: 0.5rem;
+  height: 0.5rem;
+  border-radius: 9999px;
+  background: #31f5d4;
+  box-shadow: 0 0 0 3px rgba(49, 245, 212, 0.12);
+}
+
+.proof-layer__arc-label {
+  margin-top: 0.65rem;
+  font-family: var(--font-mono), ui-monospace, monospace;
+  font-size: 0.625rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  text-align: center;
+  color: #5e6865;
+  line-height: 1.3;
+}
+
+.proof-layer__arc-connector {
+  position: absolute;
+  top: 0.25rem;
+  left: calc(50% + 0.35rem);
+  width: calc(100% - 0.7rem);
+  height: 1px;
+  background: linear-gradient(
+    90deg,
+    rgba(49, 245, 212, 0.45) 0%,
+    rgba(49, 245, 212, 0.15) 100%
+  );
+  pointer-events: none;
+}
+
+@media (min-width: 640px) {
+  .proof-layer__arc-track {
+    min-width: 100%;
+  }
+}
+
 /* IA Logotype — thin, wide tracking, teal slash */
 .ia-logotype {
   display: inline-flex;

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -25,6 +25,33 @@ const PROOF_POINTS = [
   "Executive Storytelling",
 ]
 
+const PROOF_LAYER_CARDS = [
+  {
+    title: "Future-state product ambiguity",
+    copy: "Turning early AI-native concepts into structured models, prototypes, and narratives that help teams align around what should exist next.",
+  },
+  {
+    title: "High-trust financial workflows",
+    copy: "Designing experiences where evidence, context, controls, and human judgment stay visible in complex decision-making moments.",
+  },
+  {
+    title: "Executive-ready product storytelling",
+    copy: "Making complex product capabilities tangible through demos, visual narratives, and clear product stories for leadership audiences.",
+  },
+  {
+    title: "Prototype-driven alignment",
+    copy: "Using functional prototypes and polished artifacts to help teams evaluate direction before the product is fully built.",
+  },
+]
+
+const PROOF_LAYER_ARC = [
+  "Ambiguity",
+  "Structure",
+  "Prototype",
+  "Story",
+  "Alignment",
+]
+
 const PROJECTS = [
   {
     no: "01",
@@ -270,6 +297,59 @@ export default function Home() {
           <p className="mt-5 max-w-3xl font-body text-[13px] leading-relaxed text-[#A8B3B0]/80 sm:text-sm">
             Recognized for turning complex AI and enterprise finance concepts into clear, tangible
             product stories for leadership, partner-facing, and company showcase moments.
+          </p>
+        </div>
+      </section>
+
+      {/* What teams bring me in for */}
+      <section
+        id="what-teams-bring-me-in-for"
+        aria-labelledby="proof-layer-heading"
+        className="proof-layer border-t border-[rgba(255,255,255,0.12)] px-6 py-20 lg:px-8 lg:py-28"
+      >
+        <div className="mx-auto max-w-6xl rise">
+          <p className="proof-layer__eyebrow font-mono text-xs uppercase tracking-[0.16em] text-[#7CE7D6]">
+            Where I create leverage
+          </p>
+          <h2 id="proof-layer-heading" className="monolith-title monolith-title--section mt-4">
+            What teams bring me in for
+          </h2>
+          <p className="proof-layer__intro mt-5 max-w-3xl font-body text-base leading-relaxed text-[#A8B3B0] sm:text-lg">
+            I&rsquo;m often brought into ambiguous, high-stakes product moments where teams need to
+            turn future direction into something clear, credible, and actionable.
+          </p>
+
+          <div className="proof-layer__arc" aria-hidden="true">
+            <div className="proof-layer__arc-track">
+              {PROOF_LAYER_ARC.map((step, i) => (
+                <div key={step} className="proof-layer__arc-step">
+                  <span className="proof-layer__arc-node" />
+                  <span className="proof-layer__arc-label">{step}</span>
+                  {i < PROOF_LAYER_ARC.length - 1 && (
+                    <span className="proof-layer__arc-connector" />
+                  )}
+                </div>
+              ))}
+            </div>
+          </div>
+
+          <div className="proof-layer__grid mt-10 grid gap-5 sm:grid-cols-2">
+            {PROOF_LAYER_CARDS.map((card, i) => (
+              <article key={card.title} className="proof-layer__card">
+                <span className="proof-layer__card-index font-display text-sm text-[#31F5D4]">
+                  {String(i + 1).padStart(2, "0")}
+                </span>
+                <h3 className="monolith-title monolith-title--card-sm mt-3">{card.title}</h3>
+                <p className="mt-3 font-body text-[14px] leading-relaxed text-[#A8B3B0]">
+                  {card.copy}
+                </p>
+              </article>
+            ))}
+          </div>
+
+          <p className="proof-layer__closing mt-10 max-w-3xl font-body text-[14px] leading-relaxed text-[#A8B3B0]/90 sm:text-[15px]">
+            The work is not just about designing screens. It is about making complex product direction
+            easier to understand, evaluate, and believe in.
           </p>
         </div>
       </section>

--- a/content/ask-ardavan.ts
+++ b/content/ask-ardavan.ts
@@ -17,6 +17,7 @@ export type AskArdavanPromptId =
   | "ai-native"
   | "trustworthy-ai"
   | "ies"
+  | "teams-bring-in"
   | "founder"
   | "contact"
 
@@ -77,6 +78,20 @@ export const ASK_ARDAVAN_PROMPTS: AskArdavanPrompt[] = [
       {
         label: "View the public-safe IES case study",
         href: "/work/intuit-enterprise-suite",
+      },
+    ],
+  },
+  {
+    id: "teams-bring-in",
+    label: "What do teams bring you in for?",
+    prompt: "What do teams bring you in for?",
+    assistantTitle: "What teams bring me in for",
+    answer:
+      "Teams often bring me into ambiguous, high-stakes product moments where complex ideas need to become clear, tangible, and actionable. My work tends to sit across future-state product exploration, high-trust financial workflows, executive-ready storytelling, and prototype-driven alignment.",
+    links: [
+      {
+        label: "See what teams bring me in for",
+        href: "/#what-teams-bring-me-in-for",
       },
     ],
   },

--- a/docs/sot/changelog.md
+++ b/docs/sot/changelog.md
@@ -1,5 +1,14 @@
 # Portfolio Changelog (Sprint Docs)
 
+## 2026-07-10 — Portfolio Sprint 4 — Executive Storytelling Proof Layer
+
+- Added public-safe homepage proof section: “What teams bring me in for”
+- Added ambiguity → alignment arc visual and four proof cards
+- Added Ask Ardavan V1.5 guided prompt with anchor link to proof section
+- Updated executive storytelling SOT, roadmap, claims log, and sanitized visual plan
+- Preserved guardrails around private recognition, internal teams, executive audiences, event names, and prototype details
+- No public claim changes beyond approved abstract positioning
+
 ## 2026-07-10 — Portfolio Sprint 3.2 — Share Polish
 
 - Added share image and favicon assets (`og-image.svg`, `og-image.png`, `favicon.svg`, `favicon-32x32.png`, `apple-touch-icon.png`)

--- a/docs/sot/executive-storytelling-and-future-prototypes-sot.md
+++ b/docs/sot/executive-storytelling-and-future-prototypes-sot.md
@@ -78,3 +78,27 @@ This body of work strengthens the portfolio narrative beyond screen-level design
 ## 7. Claims status
 
 All items in this SOT are **PRIVATE_CONTEXT / VERIFY** until Ardavan approves public wording, naming boundaries, and artifact publication scope.
+
+## 8. Sprint 4 public proof layer implementation
+
+**Status:** Implemented in Sprint 4 — Executive Storytelling Proof Layer
+
+### What shipped publicly
+
+- Homepage section: “What teams bring me in for” at `/#what-teams-bring-me-in-for`
+- Four abstract proof cards: future-state ambiguity, high-trust workflows, executive-ready storytelling, prototype-driven alignment
+- Lightweight ambiguity → alignment arc visual (synthetic labels only)
+- Ask Ardavan V1.5 guided prompt: “What do teams bring you in for?”
+
+### Public-safe boundaries preserved
+
+- No internal names, event names, exact team names, or prototype details
+- No confidential screenshots, private quotes, or executive names
+- Public emphasis stays abstract: executive-ready storytelling, future-state ambiguity, high-trust workflows, prototype-driven alignment
+
+### Still deferred
+
+- IES case study future-state expansion
+- Framework transfer map and prototype-to-storyboard visuals beyond homepage arc
+- Résumé bullet updates after verification
+- Naming of adjacent product areas, leadership audiences, or investor-facing events

--- a/docs/sot/portfolio-claims-log.md
+++ b/docs/sot/portfolio-claims-log.md
@@ -1,6 +1,6 @@
 # Portfolio Claims Log
 
-Version: 1.3  
+Version: 1.4  
 Last updated: 2026-07-10  
 Status: Public-safe
 
@@ -27,3 +27,7 @@ Status: Public-safe
 | Ardavan created a functioning prototype for senior leadership review. | PRIVATE_CONTEXT / VERIFY | Created executive-facing functional prototypes to help senior stakeholders evaluate future product direction. | Do not name executive reviewers, demo owner, leadership context, or prototype details until approved. |
 | Ardavan contributes to investor-facing leadership demos. | PRIVATE_CONTEXT / VERIFY | Trusted to shape executive- and investor-facing demo narratives that make complex product capabilities tangible. | Verify whether the event name and leadership/investor audience can be named publicly. |
 | Ardavan’s portfolio can emphasize executive product storytelling. | PUBLIC_SAFE when abstracted | Making complex product capabilities tangible through prototypes, narratives, and evidence-backed visual storytelling. | Supported by recognition themes; do not publish raw screenshots or private quotes. |
+| Ardavan is often brought into ambiguous, high-stakes product moments. | PUBLIC_SAFE when abstracted | I'm often brought into ambiguous, high-stakes product moments where teams need to turn future direction into something clear, credible, and actionable. | Do not name exact teams, executives, events, or prototypes without approval. |
+| Ardavan works on executive-ready product storytelling. | PUBLIC_SAFE when abstracted | Making complex product capabilities tangible through demos, visual narratives, and clear product stories for leadership audiences. | Supported by private recognition themes. Do not publish raw quotes or private screenshots. |
+| Ardavan creates functional prototypes for senior review. | PRIVATE_CONTEXT / VERIFY | Using functional prototypes and polished artifacts to help teams evaluate future product direction. | Keep abstract unless exact prototype details are approved. |
+| Ardavan contributes to investor-facing demo narratives. | PRIVATE_CONTEXT / VERIFY | External-facing product storytelling for leadership moments. | Do not name event or audience until approved. |

--- a/docs/sot/portfolio-roadmap.md
+++ b/docs/sot/portfolio-roadmap.md
@@ -1,6 +1,6 @@
 # Portfolio Roadmap
 
-Version: 1.2  
+Version: 1.3  
 Last updated: 2026-07-10  
 Status: Public-safe
 
@@ -10,8 +10,9 @@ Status: Public-safe
 - Résumé PDF is live at `/resume-ardavan-mir.pdf`
 - Static guided Ask Ardavan chat is live
 - IES public-safe case study is live at `/work/intuit-enterprise-suite`
-- QBOA public-safe case study foundation is in progress (Sprint 3)
-- Legacy claims cleanup merged (Sprint 2.1)
+- QBOA public-safe case study is live at `/work/quickbooks-dimensional-chart-of-accounts`
+- OG image, favicon, and share metadata are live (Sprint 3.2)
+- Executive storytelling proof layer homepage section is live (Sprint 4)
 
 ## Priority order
 
@@ -68,16 +69,21 @@ Reference: `docs/sot/executive-storytelling-and-future-prototypes-sot.md`
 
 ## Future sprint candidate — Sprint 4 or later
 
-**Executive Storytelling Proof Layer**
+**Executive Storytelling Proof Layer** — **Completed in Sprint 4**
 
-Potential deliverables:
+Delivered:
 
-- “What teams bring me in for” homepage section
+- “What teams bring me in for” homepage section (`/#what-teams-bring-me-in-for`)
+- Ask Ardavan V1.5 prompt: “What do teams bring you in for?”
+- Abstract ambiguity → alignment arc visual
+- Updated SOT docs and claims log
+
+Still deferred:
+
 - IES case study expansion around future-state exploration
 - Private interview walkthrough for executive prototype work
-- Sanitized visual storytelling artifacts
+- Sanitized visual storytelling artifacts beyond homepage arc
 - Résumé bullet update after verification
-- Ask Ardavan V1.5 prompt about executive storytelling
 
 ## Out of scope
 

--- a/docs/sot/sanitized-visual-plan.md
+++ b/docs/sot/sanitized-visual-plan.md
@@ -52,7 +52,14 @@ Implemented in `components/ProjectCardVisual.tsx` (decorative, aria-hidden).
 
 ## Future visual concepts — Executive storytelling / future prototypes
 
-Not yet implemented. See `docs/sot/executive-storytelling-and-future-prototypes-sot.md`.
+See `docs/sot/executive-storytelling-and-future-prototypes-sot.md`.
+
+### Sprint 4 proof-layer visuals (implemented)
+
+1. **Ambiguity → alignment arc**  
+   Homepage horizontal flow: Ambiguity → Structure → Prototype → Story → Alignment. Synthetic labels only; decorative, aria-hidden.
+
+### Sprint 4+ backlog visuals (not yet implemented)
 
 1. **Framework transfer map**  
    Shows how a core AI-native concept can be adapted from one enterprise context to another without exposing product specifics.
@@ -63,7 +70,7 @@ Not yet implemented. See `docs/sot/executive-storytelling-and-future-prototypes-
 3. **Executive alignment map**  
    Shows how ambiguity, evidence, prototype, narrative, and decision come together.
 
-4. **Investor narrative layer**  
+4. **Leadership narrative layer**  
    Shows how complex capabilities can be translated into a clear, credible story for external-facing leadership moments.
 
 ### Rules for future executive visuals


### PR DESCRIPTION
## Summary
Adds a public-safe homepage proof layer explaining what teams bring Ardavan in for, with optional Ask Ardavan V1.5 prompt support and SOT updates.

## Included
- Homepage proof section
- Public-safe executive storytelling positioning
- Ask Ardavan V1.5 prompt, if implemented
- Updated SOT docs and claims log

## Safety
- No confidential screenshots
- No private quotes
- No executive names
- No internal team names
- No internal product acronyms
- No event names
- No metrics
- No unsupported ownership/impact verbs
- No backend/API changes
- No new dependencies

## QA
- pnpm build passed

Made with [Cursor](https://cursor.com)