### PR TITLE
Regenerate public resume PDF

### DIFF
--- a/docs/sot/changelog.md
+++ b/docs/sot/changelog.md
@@ -1,5 +1,12 @@
 # Portfolio Changelog (Sprint Docs)
 
+## 2026-07-10 — Portfolio Sprint 5A.1 — Résumé PDF Regeneration
+
+- Regenerated `public/resume-ardavan-mir.pdf` from `content/resume.md` using local ReportLab (outside repo dependencies)
+- Added `resume-pdf-generation.md` with method, checks, and manual fallback steps
+- Preserved public path `/resume-ardavan-mir.pdf`
+- No new claims, metrics, or confidential content added
+
 ## 2026-07-10 — Portfolio Sprint 5A — Verified Résumé Polish
 
 - Updated résumé source to align with current portfolio positioning

--- a/docs/sot/portfolio-roadmap.md
+++ b/docs/sot/portfolio-roadmap.md
@@ -7,7 +7,7 @@ Status: Public-safe
 ## Current status
 
 - Homepage is live with AI-native legibility positioning
-- Résumé PDF is live at `/resume-ardavan-mir.pdf` (source updated in Sprint 5A; PDF regeneration pending review)
+- Résumé PDF is live at `/resume-ardavan-mir.pdf` (regenerated from source in Sprint 5A.1)
 - Résumé markdown source aligned with portfolio positioning (`content/resume.md`)
 - Static guided Ask Ardavan chat is live
 - IES public-safe case study is live at `/work/intuit-enterprise-suite`

--- a/docs/sot/resume-claims-review.md
+++ b/docs/sot/resume-claims-review.md
@@ -1,8 +1,8 @@
 # Résumé Claims Review
 
-Version: 1.1  
+Version: 1.2  
 Last updated: 2026-07-10  
-Sprint: 5A — Verified Résumé Polish (pre-merge tighten)  
+Sprint: 5A.1 — Résumé PDF Regeneration  
 Status: Public-safe review doc — not published as site copy
 
 ## 1. Current résumé status
@@ -10,11 +10,10 @@ Status: Public-safe review doc — not published as site copy
 | Item | Status |
 |------|--------|
 | Markdown source | `content/resume.md` — updated in Sprint 5A |
-| Public PDF | `public/resume-ardavan-mir.pdf` — **unchanged** in Sprint 5A |
+| Public PDF | `public/resume-ardavan-mir.pdf` — **regenerated in Sprint 5A.1** from source |
 | Homepage link | `/resume-ardavan-mir.pdf` |
-| PDF generation workflow in repo | **None** — no `package.json` script or documented safe generator |
-
-**TODO:** Regenerate public résumé PDF from `content/resume.md` after Ardavan reviews the source.
+| PDF generation workflow in repo | **None** — local ReportLab used in Sprint 5A.1 (see `resume-pdf-generation.md`) |
+| PDF matches source | **Yes** — as of Sprint 5A.1 |
 
 ## 2. Public-safe positioning
 

--- a/docs/sot/resume-pdf-generation.md
+++ b/docs/sot/resume-pdf-generation.md
@@ -1,0 +1,79 @@
+# Résumé PDF Generation
+
+Version: 1.0  
+Last updated: 2026-07-10  
+Sprint: 5A.1 — Résumé PDF Regeneration
+
+## Source of truth
+
+| Item | Path |
+|------|------|
+| Canonical résumé source | `content/resume.md` |
+| Public PDF | `public/resume-ardavan-mir.pdf` |
+| Public URL | `/resume-ardavan-mir.pdf` |
+
+## Repo workflow status
+
+| Check | Result |
+|-------|--------|
+| `package.json` script | **None** |
+| Documented repo generator | **None** (Sprint 5A.1) |
+| Prior live PDF producer | ReportLab (observed in existing PDF metadata) |
+
+## Sprint 5A.1 generation method
+
+**Method used:** Local-only ReportLab generation via temporary Python environment (not added to repo dependencies).
+
+Steps performed:
+
+1. Verified `content/resume.md` is public-ready (no VERIFY/TODO/placeholder/private terms).
+2. Generated candidate PDF locally using ReportLab (installed to `/tmp/pdflibs` via `pip install --target`, outside repo).
+3. Verified candidate PDF:
+   - Valid PDF (1 page)
+   - Selectable/searchable text
+   - Matches `content/resume.md` structure and wording
+   - No risky terms (metrics, unsupported verbs, private names)
+4. Replaced `public/resume-ardavan-mir.pdf` with candidate after review.
+5. Did **not** commit `resume-ardavan-mir-candidate.pdf`.
+
+**Why not Playwright/Firefox headless:** Chromium/Firefox headless crashed in this environment (graphics sandbox). HTML print export remains a fallback.
+
+## Manual export fallback (if automation unavailable)
+
+1. Open `content/resume.md` and copy public-ready content into a print-ready HTML or design tool.
+2. Use browser Print → Save as PDF (Letter, 0.55–0.6 in margins).
+3. Save as `public/resume-ardavan-mir-candidate.pdf` for review first.
+4. Compare text against `content/resume.md`.
+5. Replace `public/resume-ardavan-mir.pdf` only after review.
+
+## Checks run (Sprint 5A.1)
+
+- [x] `content/resume.md` has no VERIFY/TODO/placeholder language
+- [x] Candidate PDF opens locally
+- [x] Candidate PDF text matches source structure (IES, QBOA, QBO Money, Iranians Who Design)
+- [x] No 20%/26%/40%, launched/shipped, led/owned/drove, or private terms in PDF text
+- [x] Public path preserved: `/resume-ardavan-mir.pdf`
+- [x] `pnpm build` passed
+- [x] Static export includes résumé PDF
+
+## PDF replacement status
+
+| Item | Status |
+|------|--------|
+| Candidate generated | Yes (local ReportLab) |
+| Live PDF replaced | **Yes** — Sprint 5A.1 |
+| Public path unchanged | Yes |
+
+## Remaining TODOs
+
+- Confirm Intuit role dates and official HR titles with Ardavan before next PDF update
+- Confirm QBO Money bullet scope
+- Add verified earlier experience when approved
+- Optional: add a repo-local generation script only if ReportLab (or another tool) is approved as a dev dependency
+
+## Manual review notes
+
+- Live PDF now aligns with Sprint 5A résumé source positioning
+- One-page layout; ATS-readable Helvetica text
+- No phone number included (not in source)
+- No new claims beyond approved `content/resume.md`

--- a/public/resume-ardavan-mir.pdf
+++ b/public/resume-ardavan-mir.pdf
@@ -32,8 +32,8 @@ endobj
 endobj
 6 0 obj
 <<
-/Author (Ardavan Mirhosseini) /CreationDate (D:20260709202741+00'00') /Creator (anonymous) /Keywords () /ModDate (D:20260709202741+00'00') /Producer (ReportLab PDF Library - \(opensource\)) 
-  /Subject (unspecified) /Title (Ardavan Mirhosseini Resume) /Trapped /False
+/Author (\(anonymous\)) /CreationDate (D:20260710164412-04'00') /Creator (\(unspecified\)) /Keywords () /ModDate (D:20260710164412-04'00') /Producer (ReportLab PDF Library - \(opensource\)) 
+  /Subject (\(unspecified\)) /Title (\(anonymous\)) /Trapped /False
 >>
 endobj
 7 0 obj
@@ -43,10 +43,10 @@ endobj
 endobj
 8 0 obj
 <<
-/Filter [ /ASCII85Decode /FlateDecode ] /Length 3489
+/Filter [ /ASCII85Decode /FlateDecode ] /Length 1964
 >>
 stream
-Gb!#^>BALh(4PFJo[D=XPYlP;]IgR3L>)DX##DO)o?n3[oN5j*/]fnLqr@F@mZnEhEU[.T;Q0db:nQKd^2jkrZ/Lb=r_7H#Nb@FjR6qs\bSJ.e/YC6NOn!6q3Na$K$*bI7Y`fo1K.mcu,*rCSMb@:cDfI!P1q19`N]Go'8`[j$QBQfWjIG((6-d#G'kPLsi;Y(/^W>bC--#X'3rh!S\/PV@Wo%a634@8ZI9MGj-m;M9GTk1o/EV(YO],<OV-pSZaMX3/!X;iBZDEiFOP!In-W]Ru/]RLLQrtR?;&)U^nq)u'&jj!C3L<cMjQ`M!Md&+&!^HIq`J<h^^:E9279sInESK=VqH7_">+lbC?,[K38OA27M&Z3r^8SPHIiLH/INVJ#0X42EJk06[AD6f2Yla#LB,fE7rS91gN,7n7S+H7!om[HLaGO2]_>lF`@TQjC)PO("5eB(7%mjH$V'("8fORjTFiidA&;5mtagL1U,?%447q=Fo$<ls]7d^Y0]?#m,nq^*s-OVQ*83+pU(4ILZpFVB1E`6!i0.eq&Q)(.uBZ171Dk4-<!j\jN#;u##YB@qj.nc&.BU1BXA0p2b*0RQQs-g2;ZJs'XY``r==_gCu/)^5hc6`1gAs+s4_K"*u(A2\Oa"@^eK5G!SQ0F0-/?NXn+rX+r>^>N="]\"!=`^jt`d_'qlW]K0]di*?@Mut.Bp!1sJqoTk;QdhLA0S%B=(L+V41o2ub3q2`DiXqa-+O_/!$e7!j?UlMTHgX@qo&XZKh=Js#Kt^L>4N<DS'tTgUNLu(6Xh6-dYq&Fj:TKAaU#C.U[T;cGgqPc5nGK$#CXmDgUB$!$=W=Nl]oR,`1a"FAc1Y)Hp&?SS;^gB@6oimFcP_PS\00+CA)(`hUO2uN,JN%qPWXKjSOmO1-WS((6J<2S+-<R\CJIf/0@^GdD`Meg^HIg.fjok8I5g/f\q`>p,s%A[ZU-Y'1Lt@QE>^,k%oTF7CW?CnlkMsdsXk7-@*\&9?9(d5=i_@M/^s""p"C3`1\N/K96718.4hqQ"cb4-qn]>!W+ZHd&8FmPY-3qIf&g-)_DuN5b8)*l`,>s$*SHbk8JA>c8R_OGPQ6JhCYLFM6KAEBgsDP2FlM\kF$dKa636bU\uOOT&CSS<cnn*o2e(^k2:Y^)'D8?%k:^m^`'LDE]5/9Bj0!f,HJO>^:kLtr-!u0]T#)HmlK:-26K$'$ii>,D&n)%.C::0+_f6KF60h3(]]XZ?In&d/M<]td#+oH$38=o!5IE6G0ltlJS9ZO;Gj,;?K3iWlC>t:`RgalPne8XE'_s],b\#5fT:,RgntiOT,/>t^4#/liRW'HcAJIVItPi_ZV<^0hPb7&%kOh_[W`,;;<,,;6ooT;klNT'J)s>Er68QWq+q3'j#03lpek\+p;3?%R@%L#C/b1Tf4'b/$PK4dIrg@@oW_b0a8UPK=cQBpJ(9"'!oU[k@#&Vi*@Ln?'EG3:4X0u2DJ+l]l&$\WBk(p+[l^-*(MQprn\^QL_GF1rW'O6J$)+(rpV%sjp61OZ\>I4jfT`>I9CZE(^oF/;+kaGg<LY@WQ?!Zs1qh8EV,8oq/,YS,$c.+_IsIm>I*XX(L:&hY&IIkT;jur7$OLmAWp5;1(RY=Z3%EA[O.@@iS1n3t65<=9>=4gY9*=;f%!_c>MWoI^O+t%L!6HbJIo<ebajf4/0?JJ_fLG&>"KeH1ppXbSAC>N/[*f!QNm7[7kA].sP=;ub0lkLEN*Ob)VrfID/9>4@@6<]6at'"s.I4ABm'\IGHN&<XiS/N[LNS$qrJ[_c(uH$I68qHJDc@ai`7_,k=SDRB)QPA6Ql`0LX8s5)\j>kZD%!:S%S1m_<[uV(_/uShko$.#'Ua(@!Yq^XB/Jf)jrJ_nX+1SQMoM^EF%jGiQZDLr<ZkD?70\uT80*5\.'cb&DQm2l#/+DuXYHJH22d:4U((Kd*S4lW/j9M:08NfOdIbs/^Q!NMko5_5CjB7FDm8-<;$bp(-q5NV"=7MUlD\?g!Iu_)<].7:Q"dP\",pPB[;.IV1PRn^jgtT"<<<.<.mQ-ecS9,]"r3=n%^*Kt\3.(nk)8J?G?>!YeM'Q!4`X8`X?e,+QRWp,O2A@"-XE`,_<s_#n)+71GF:oh'F]Aa.(7PHI"@;egi!n_38(,C;u1[lQS"Q>9YD'-<\-0k6`?t[9hla\:Z1\0pM,*1-L;2?)qusHBNT@$B-h;h7'%ZB]u5WV#^kj/3F^o6(i]X?#bi.hZ9]&6QLDEMirIl(GZGAETtZOY3l$Xb*1WFt:k-0l&%B;u)SW(@!+'4=01ke-psr)!\*>n)HlK7S8>\&!jRu'iaQT*'<eJApYMH)O2D0aWY57MUk2LK19dU[?fjlq/r:-MXRQAP$RSC@8F>mrqT+HDM!Qe"'feLUt@$jJ73%e;tY6kBWVskdB6*>]NMCBE\@(O'aF[2Er=1&pk-+*=!g=a[rHN9#F3MGD!UU7il$mUi7.WKQG"N.S&JHKluQ@e%CP7aC$7u$7"KN4m7Z4]Y9CR_D)_Q3odL>7OfI/e1P&t</qEtjl9h:]NKn_6.=j%6MIfSgETf,_+/&32("dsk.WI@@kab<^s]"c[,Bh0BM%"Cr"^Ae9XOBjnK4+,%qW7IBe3j5%a:4j3D>L7lqIN40JHRi(<K?/s5a2<Rq'`TUHn]<c1AFI'n@cEarmU!TZY9`3]4Dr8L(G-Gc?\$L@piqt(eRWc)e[aqdT3.<uZ^C<SYkWq6V>rMl*F<dG_Kc[R5E@o#kjDK1DdgdJo/2Hk/(B1#Z\8MG0_!`1c`g8^Q[m'T&=5&u1l-0OA4-pa:/J5KUo1Y"ff0?M$n_JpM5"[l>nR:0$?Y;f&Z$eUn93socc>$mh_iT+6'*S>Df"[P!UJl1XE049ijbM51N,[_%CM1\;*5-Rj&<&ufkr>R)MIeIg(5mnZ^dj:QYce):5r"MJF>(/_dUQ)!9r/(>KPk'KVGB;'f)$WRd15dH*U8>QHdP.58c,mhKr*fPpB6>(gBG2:a0HKB4\ou^BU5nL_g%d2"!mG1'A(6>+W3HW:-UJS5l^Q$1\`e56Y5n8FF?1ReRmDXR'A8-^6EOu2hn(ahrsAJa>]\(2^q"#.f"lV:pqOBHRe4W`S4-]3cpskR?0VhikN5Aga"QkE:\dR0NmoLBDn7e`aJuDM\""^n40P<+(.&b+$*mmq(A!02]VYidI2Znj+Pc:5b":(0?MI7?p'BJ)O4C(7E-])0^k\%!!?nG(Tc-41&EK.DVM>\5iF(=X013a!8rK:aS@4FLh<F8UBdIBd#^>YbYD=PfKXolm%t`sm:=Yl!<1cQ2qsn!BaZ6uVe9jb(&`C3SZ(cRN`fQHqF<ZXBom-_R:,]O473'o$"6d1cR6&ST*YKmd/:o6N'sue(Uo0[?O,9P#6nWb;uk#s#RDMF:tm:D@c2nE9CQ30M^"LtH<5?tSu[PlGW4-Hn6,CXaETFUIXhDs7%H,3(:?iJ5UV3a!Um,S,6~>endstream
+Gatm<?$G!^&:Mm.R)eV9+P;d;]IckAen5qb!r^bmqP)UDX0EsOP1.k.+29&B++aL\-JS/<6'4VmGOEZq4+KMD"nm;5"2%sUl'h[)&/InEL:n`]hSE`Bo$9m(mMoR,65YCmpnp*lotF^uWtRT6eCO,:Ng<!;cE3oNA*;BeG!5gaT#+2YH[@iH:SMRq)_A_?icfIaHi2U2-O<oDl(,ASd-&.=*Uap!]B5>6+lQ1RUkgm5;oMe-9)'$R,FEFEj]XE.@8=nV"66=A-(6tppa"q<1)&PE#Mq.0Gg&\_o8V0T=3$jp^HAQe`D>q%&UuH,G=1]a6:er#keQR">s'20OU6:Y4D43q;<U]0LL)NPpU?+O#F[>a<_aMsD>*Ch2*5!S*Y!QUQ$q!9q1kH/na,][g\p)NgLjjdIN`o.&Jp<O+?7_2)<<E&hjOrdT"qYWU2jE'5m1@(Xtl_c'u2=&C7Wc@J2_/(j(7B>IA%LU8jSu1/>IS]'ei;pA9>fY1YRDEXjXA<GR2ls]Cbuh8k+)bRrp2LYtFQ5;TKjV'>2&Aa>db"`k%7FW:Ci>)f<W_dmA!(N3?J/Q$r:#DD]V""fi^"Cd?DciNO(_XYDMc\1X0*U,d\"`_:gZqguctYE;lnDE6FF0M[]d0hp"4VGl7Y1gd.K0kCpBaTGiT'i%P4KfGhq;V?V+88:uB#jsDq2'HHH'Fc8!#U7)m"RdAod+LhqLCWhFYNXfSH&Loq>BdX59@%H]\rth4-uO#E_5&Eqf(LJnV-ZVXUeMMCbL%C)N'6mE?.GXNM^n=V'RPSV?YL(b7JP9gf'X'@@?.1Xl"]5omMZ_(EIOg*@EPZpAF@jmmJ4h&JW]b_B2haGGP$[VPT!0Iod_JUl7NH^IDJ9P,0S'@O>^4MVmNc4e1)gtfaZ]A]9bL@cZbRU1mqZES5_o*`J8-SE`H>9X4r*5.oWTKO..4tp)@F#a+#>drV8"83Q8AdU?R46DBD$B!"ZK1T5^a@s+ITu%M8:(4,J(<D5[lhO80O#fjdhRIL/IgGY>A#.S2snVXp4iKT.Q:3/`ptSsWJO2dt?M/LRe;&,"OLXXd_UX:*"2/D!!IWH,":G#2Nt?s=p,G;t`53iHe1Y]WS.<]%J?Whlg-K@((R.s%"A1u=Cm7f$ja/7+o?2S.l3[*otlmm_*PN(Bg)NH!B^_D8G-oT:H^)AM*R8"oc_,c_mcG%ffq+H6J,MQ?u:_8Xen[KVF:8WbW^]i:8fm0A*Ch!<g\(ah1C8s3*dYA/0m9&69.Q;'hgBHS3k7o31@VU[T3X9_e#X9l?LM1lm_PYe>W[W]mOD6fs.gjINScIq;P^bH.'pOrVRah956KtBsH!qU0Cj%`YKI0KA7X]!$Aa>R@)em[==;91:m+3ebgMhG\h^i#7u@d9,9#C@C*KDl7_R*f$;\E/H:&3A#5@1!5C3uU9L&DN?$#17.Jm>lq%))o77.Fl"gefPnoIaaBhWOM(n'iZ,%_6_)=rTi3ag2o)sc1!Vkc2];U3#O>W*64f3(jq6TKLReWGT:oc]Qf9BbYqsXP#Q<4kF>+Re&L_%"\f:5.g7kRdg"I;a>E30?C][0P[[913OmGP3IWQU0t9A#-T#Gt7(8]%)4jW#ZhB@;,p-<R(67+I4D8YYPucGSLJ!8F(jA"2G:u#3O(3rEY0HjMB2e4fE4S?X4<8o+O=5-[$;*(-/T)!NHK-^k[p(*Kr,IdI[S(j@B[62sM>!Q!gL(DLqYSIrn8(4H`mZqqH@$%OPBlf`[,p.nq!?ZN'nD^mfh\Rqo5so5TFpc3&'AgDX^)p0]iR^;i4ffL_:eiD@T3H0hK0Ef/Y*!(7,!leTobZUTEM@W&2kS?(>&jaqacaLh7^0\;;kVmk"4H[,EOSoMaq;%DJETY&AD[1(pDO/_jCq[\Rp6;G1*F]g,OBK(!OU5PSCC=?!%Bph,')o;bUXfY<skugXOU;L']7-!q>1c^&~>endstream
 endobj
 xref
 0 9
@@ -57,12 +57,12 @@ xref
 0000000321 00000 n 
 0000000514 00000 n 
 0000000582 00000 n 
-0000000871 00000 n 
-0000000930 00000 n 
+0000000862 00000 n 
+0000000921 00000 n 
 trailer
 <<
 /ID 
-[<ce95a260ff139f43034e88c6bfae9915><ce95a260ff139f43034e88c6bfae9915>]
+[<b8643fd7b92dd25bf0535c3f89301570><b8643fd7b92dd25bf0535c3f89301570>]
 % ReportLab generated PDF document -- digest (opensource)
 
 /Info 6 0 R
@@ -70,5 +70,5 @@ trailer
 /Size 9
 >>
 startxref
-4510
+2976
 %%EOF


### PR DESCRIPTION
## Summary
Regenerates the public résumé PDF from the cleaned résumé source (`content/resume.md`) using a local ReportLab workflow documented in SOT.

## Included
- Updated `public/resume-ardavan-mir.pdf` (matches Sprint 5A source)
- `resume-pdf-generation.md` with method, checks, and manual fallback
- Resume claims review and changelog updates

## Safety
- No new claims
- No metrics
- No confidential screenshots
- No private quotes
- No executive names
- No internal team names
- No internal product acronyms
- No event names
- No unsupported ownership/impact verbs
- No dependency or deployment changes
- Public path preserved: `/resume-ardavan-mir.pdf`

## QA
- pnpm build passed
- Static export includes résumé PDF
- PDF text verified against source (1 page, selectable text)

Made with [Cursor](https://cursor.com)