### PR TITLE
Add research strategy layer

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -1482,3 +1482,130 @@ img {
     grid-template-columns: 1fr;
   }
 }
+
+/* Research & Strategy visuals (Sprint 8) */
+.research-visual {
+  margin-top: 0.5rem;
+  padding: 1.25rem;
+  border-radius: 6px;
+  background: rgba(17, 23, 25, 0.85);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+}
+
+.research-visual__caption {
+  font-family: var(--font-ui);
+  font-size: 0.6875rem;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: #f4f7f6;
+}
+
+.research-visual__blurb {
+  margin-top: 0.5rem;
+  font-family: var(--font-body);
+  font-size: 0.8125rem;
+  line-height: 1.55;
+  color: #a8b3b0;
+}
+
+.research-visual__svg {
+  display: block;
+  width: 100%;
+  height: auto;
+  margin-top: 1rem;
+}
+
+.research-visual__pipeline {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.35rem 0.25rem;
+  margin-top: 1rem;
+  padding: 0;
+  list-style: none;
+}
+
+.research-visual__pipeline-step {
+  display: flex;
+  align-items: center;
+  gap: 0.35rem;
+}
+
+.research-visual__pipeline-node {
+  width: 0.5rem;
+  height: 0.5rem;
+  border-radius: 50%;
+  background: #31f5d4;
+  opacity: 0.75;
+  flex-shrink: 0;
+}
+
+.research-visual__pipeline-label {
+  font-family: var(--font-mono);
+  font-size: 0.625rem;
+  letter-spacing: 0.06em;
+  color: #a8b3b0;
+  white-space: nowrap;
+}
+
+.research-visual__pipeline-connector {
+  width: 0.75rem;
+  height: 1px;
+  background: rgba(49, 245, 212, 0.35);
+  flex-shrink: 0;
+}
+
+@media (max-width: 640px) {
+  .research-visual__pipeline {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+
+  .research-visual__pipeline-connector {
+    width: 1px;
+    height: 0.5rem;
+    margin-left: 0.2rem;
+  }
+}
+
+.research-card__visual {
+  position: relative;
+  height: 2.5rem;
+  border-radius: 4px;
+  background: rgba(49, 245, 212, 0.04);
+  border: 1px solid rgba(49, 245, 212, 0.12);
+  overflow: hidden;
+}
+
+.research-card__visual-line {
+  position: absolute;
+  top: 50%;
+  left: 12%;
+  right: 12%;
+  height: 1px;
+  background: linear-gradient(
+    90deg,
+    rgba(49, 245, 212, 0.2),
+    rgba(49, 245, 212, 0.55),
+    rgba(124, 231, 214, 0.3)
+  );
+  transform: translateY(-50%);
+}
+
+.research-card__visual-node {
+  position: absolute;
+  top: 50%;
+  right: 18%;
+  width: 0.45rem;
+  height: 0.45rem;
+  border-radius: 50%;
+  background: #31f5d4;
+  opacity: 0.7;
+  transform: translateY(-50%);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .research-flow-line {
+    animation: none !important;
+  }
+}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -8,6 +8,7 @@ import ClarityEngine from "@/components/portfolio/clarity-engine"
 import IALogotype from "@/components/ia-logotype"
 import PortfolioChat from "@/components/PortfolioChat"
 import ProjectCardVisual from "@/components/ProjectCardVisual"
+import { RESEARCH_ENTRIES, RESEARCH_SECTION } from "@/content/research"
 
 const NAV = [
   { id: "work", label: "Work" },
@@ -444,6 +445,74 @@ export default function Home() {
               </a>
             </div>
           ))}
+        </div>
+      </section>
+
+      {/* Research & Strategy */}
+      <section
+        id="research-strategy"
+        aria-labelledby="research-strategy-heading"
+        className="border-t border-[rgba(255,255,255,0.12)] px-6 py-16 lg:px-8 lg:py-20"
+      >
+        <div className="mx-auto max-w-6xl">
+          <p className="font-mono text-xs uppercase tracking-[0.16em] text-[#7CE7D6]">
+            {RESEARCH_SECTION.eyebrow}
+          </p>
+          <h2 id="research-strategy-heading" className="monolith-title monolith-title--section mt-4">
+            {RESEARCH_SECTION.heading}
+          </h2>
+          <p className="mt-4 max-w-3xl font-body text-[15px] leading-relaxed text-[#A8B3B0] sm:text-base">
+            {RESEARCH_SECTION.intro}
+          </p>
+
+          <div className="mt-10 grid gap-5 md:grid-cols-3">
+            {RESEARCH_ENTRIES.map((entry, i) => (
+              <article
+                key={entry.id}
+                className="research-card flex flex-col rounded-[6px] border border-[rgba(255,255,255,0.12)] bg-[#111719] p-6"
+              >
+                <span className="font-display text-sm text-[#31F5D4]">
+                  {String(i + 1).padStart(2, "0")}
+                </span>
+                <div className="research-card__visual mt-3" aria-hidden="true">
+                  <span className="research-card__visual-line" />
+                  <span className="research-card__visual-node" />
+                </div>
+                <h3 className="monolith-title monolith-title--card-sm mt-4">{entry.title}</h3>
+                <p className="mt-2 font-ui text-[11px] uppercase tracking-[0.1em] text-[#7CE7D6]/90">
+                  {entry.eyebrow}
+                </p>
+                <p className="mt-3 flex-1 font-body text-[13px] leading-relaxed text-[#A8B3B0]">
+                  {entry.summary}
+                </p>
+                <div className="mt-5 flex flex-col gap-2">
+                  <Link
+                    href={entry.href}
+                    className="font-ui text-[11px] uppercase tracking-[0.12em] text-[#31F5D4] transition-colors hover:text-[#7CE7D6]"
+                  >
+                    {entry.ctaLabel} →
+                  </Link>
+                  {entry.externalHref && entry.externalCtaLabel ? (
+                    <a
+                      href={entry.externalHref}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      className="font-ui text-[11px] uppercase tracking-[0.12em] text-[#A8B3B0] transition-colors hover:text-[#31F5D4]"
+                    >
+                      {entry.externalCtaLabel} ↗
+                    </a>
+                  ) : null}
+                </div>
+              </article>
+            ))}
+          </div>
+
+          <Link
+            href={RESEARCH_SECTION.ctaHref}
+            className="mt-8 inline-flex font-ui text-[11px] uppercase tracking-[0.12em] text-[#31F5D4] transition-colors hover:text-[#7CE7D6]"
+          >
+            {RESEARCH_SECTION.ctaLabel} →
+          </Link>
         </div>
       </section>
 

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -485,23 +485,13 @@ export default function Home() {
                 <p className="mt-3 flex-1 font-body text-[13px] leading-relaxed text-[#A8B3B0]">
                   {entry.summary}
                 </p>
-                <div className="mt-5 flex flex-col gap-2">
+                <div className="mt-5">
                   <Link
                     href={entry.href}
                     className="font-ui text-[11px] uppercase tracking-[0.12em] text-[#31F5D4] transition-colors hover:text-[#7CE7D6]"
                   >
                     {entry.ctaLabel} →
                   </Link>
-                  {entry.externalHref && entry.externalCtaLabel ? (
-                    <a
-                      href={entry.externalHref}
-                      target="_blank"
-                      rel="noopener noreferrer"
-                      className="font-ui text-[11px] uppercase tracking-[0.12em] text-[#A8B3B0] transition-colors hover:text-[#31F5D4]"
-                    >
-                      {entry.externalCtaLabel} ↗
-                    </a>
-                  ) : null}
                 </div>
               </article>
             ))}

--- a/app/research/page.tsx
+++ b/app/research/page.tsx
@@ -1,0 +1,246 @@
+import type { Metadata } from "next"
+import Link from "next/link"
+import IALogotype from "@/components/ia-logotype"
+import ResearchStrategyVisuals from "@/components/ResearchStrategyVisuals"
+import { openGraphShareImages, SITE_URL, twitterShareImages } from "@/lib/site"
+
+const ogImageAlt =
+  "Ardavan Mirhosseini — Research and strategy for AI-native design, collaboration, and platform patterns."
+
+export const metadata: Metadata = {
+  title: "Research & Strategy — Ardavan Mirhosseini",
+  description:
+    "Strategic research and operating models for AI-native design, GitHub-based collaboration, platform patterns, and high-trust product workflows.",
+  alternates: {
+    canonical: "/research",
+  },
+  openGraph: {
+    title: "Research & Strategy — Ardavan Mirhosseini",
+    description:
+      "Strategic research and operating models for AI-native design, GitHub-based collaboration, platform patterns, and high-trust product workflows.",
+    url: `${SITE_URL}/research`,
+    type: "website",
+    images: openGraphShareImages(ogImageAlt),
+  },
+  twitter: {
+    card: "summary_large_image",
+    title: "Research & Strategy — Ardavan Mirhosseini",
+    description:
+      "Strategic research and operating models for AI-native design, GitHub-based collaboration, platform patterns, and high-trust product workflows.",
+    images: twitterShareImages,
+  },
+}
+
+const SECTIONS = [
+  {
+    id: "architectures-of-intent",
+    title: "Architectures of Intent",
+    subtitle: "An AI-native strategy guide for enterprise software as an operating model",
+    copy: [
+      "This public research artifact explores what enterprise software becomes when AI is no longer treated as a feature layer and instead becomes part of the product operating model.",
+      "The work frames AI-native strategy around intent, infrastructure, workflow, and the systems that help people understand, evaluate, and act with confidence.",
+    ],
+    covers: [
+      "AI as operating model",
+      "Intelligence as infrastructure",
+      "Enterprise product transformation",
+      "Strategic product framing",
+      "Systems thinking",
+      "Architectures of intent",
+    ],
+    demonstrates: [
+      "AI-native product strategy",
+      "Research synthesis",
+      "Executive-ready narrative framing",
+      "Systems-level product thinking",
+    ],
+    visual: "architectures-of-intent" as const,
+    externalHref: "https://v0-ai-native-strategy-research.vercel.app/",
+    externalLabel: "Open interactive guide",
+  },
+  {
+    id: "github-design-collaboration",
+    title: "GitHub-Based Design Collaboration",
+    subtitle: "A design operating model for integrated, AI-ready prototype work",
+    copy: [
+      "This research explored how design teams can use GitHub workflows, shared foundations, team-owned slices, generated route registries, pull-request review, and validation to bring multiple product workstreams into one coherent prototype or release model.",
+      "The focus was not on making every designer an engineer. It was on making collaboration more structured, reviewable, and automation-ready — so teams could contribute to a shared product story without fragmenting the experience.",
+    ],
+    covers: [
+      "Shared shell and navigation ownership",
+      "Team-owned slices or workstreams",
+      "Reusable foundations",
+      "Generated route registry",
+      "Pull-request-based contribution",
+      "CODEOWNERS and review paths",
+      "Static review artifacts",
+      "AI-ready contribution rails",
+    ],
+    demonstrates: [
+      "Systems thinking",
+      "Design engineering fluency",
+      "Workflow design",
+      "Governance",
+      "Prototype strategy",
+      "Cross-team alignment",
+    ],
+    visual: "github-design-collaboration" as const,
+  },
+  {
+    id: "ai-native-platform-patterns",
+    title: "AI-Native Platform Patterns",
+    subtitle: "Research patterns for trustworthy AI-native product experiences",
+    copy: [
+      "This research synthesized recurring patterns across AI-native product experiences: how systems gather context, ground recommendations, expose reasoning, support review, respect permissions, and move from suggestion to action.",
+      "The strongest AI-native products do not rely on intelligence alone. They make the system understandable, keep people in control, and create clear moments for review, correction, approval, and recovery.",
+    ],
+    covers: [
+      "Observe → Act → Build modes",
+      "Context and memory",
+      "Grounding and source evidence",
+      "Permissions and governance",
+      "Review and editing",
+      "Human control",
+      "Uncertainty handling",
+      "Suggestion-to-action workflows",
+      "Feedback and recovery loops",
+      "Decision architecture",
+    ],
+    demonstrates: [
+      "AI product strategy",
+      "Research synthesis",
+      "Pattern recognition",
+      "Trust and governance thinking",
+      "Platform-level design judgment",
+    ],
+    visual: "ai-native-platform-patterns" as const,
+  },
+]
+
+export default function ResearchPage() {
+  return (
+    <main className="min-h-screen overflow-x-hidden bg-[#05070A] text-[#F4F7F6]">
+      <header className="border-b border-[rgba(255,255,255,0.08)] bg-[#05070A]/90 backdrop-blur-md">
+        <div className="mx-auto flex h-16 max-w-3xl items-center justify-between px-6 lg:px-8">
+          <IALogotype />
+          <Link
+            href="/#work"
+            className="font-mono text-xs uppercase tracking-[0.16em] text-[#A8B3B0] transition-colors hover:text-[#31F5D4] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#31F5D4]"
+          >
+            Back to work
+          </Link>
+        </div>
+      </header>
+
+      <article className="mx-auto max-w-3xl px-6 py-16 lg:px-8 lg:py-24">
+        <p className="font-mono text-xs uppercase tracking-[0.16em] text-[#7CE7D6]">
+          Research & Strategy
+        </p>
+        <h1 className="monolith-title monolith-title--section mt-4">
+          Operating models for AI-native design
+        </h1>
+        <p className="mt-6 font-body text-base leading-relaxed text-[#A8B3B0] sm:text-lg">
+          A collection of public-safe research summaries and frameworks exploring how design teams
+          can collaborate, prototype, and govern AI-native product work.
+        </p>
+        <p className="mt-4 font-body text-[14px] leading-relaxed text-[#A8B3B0]/90">
+          These summaries are intentionally sanitized. They focus on public-safe themes, methods, and
+          patterns rather than internal documents, private feedback, or confidential workflow details.
+        </p>
+
+        {SECTIONS.map((section, index) => (
+          <section
+            key={section.id}
+            id={section.id}
+            className={`research-section ${index > 0 ? "mt-20 border-t border-[rgba(255,255,255,0.08)] pt-20" : "mt-16"}`}
+          >
+            <h2 className="monolith-title monolith-title--card">{section.title}</h2>
+            <p className="mt-2 font-ui text-[12px] uppercase tracking-[0.12em] text-[#7CE7D6]">
+              {section.subtitle}
+            </p>
+            {section.copy.map((paragraph) => (
+              <p
+                key={paragraph.slice(0, 40)}
+                className="mt-5 font-body text-[15px] leading-relaxed text-[#A8B3B0]"
+              >
+                {paragraph}
+              </p>
+            ))}
+
+            <div className="mt-8 grid gap-8 sm:grid-cols-2">
+              <div>
+                <h3 className="font-ui text-[11px] uppercase tracking-[0.14em] text-[#F4F7F6]">
+                  What it covers
+                </h3>
+                <ul className="mt-3 space-y-2 font-body text-[14px] leading-relaxed text-[#A8B3B0]">
+                  {section.covers.map((item) => (
+                    <li key={item} className="flex gap-2">
+                      <span className="text-[#31F5D4]" aria-hidden="true">
+                        ·
+                      </span>
+                      {item}
+                    </li>
+                  ))}
+                </ul>
+              </div>
+              <div>
+                <h3 className="font-ui text-[11px] uppercase tracking-[0.14em] text-[#F4F7F6]">
+                  What it demonstrates
+                </h3>
+                <ul className="mt-3 space-y-2 font-body text-[14px] leading-relaxed text-[#A8B3B0]">
+                  {section.demonstrates.map((item) => (
+                    <li key={item} className="flex gap-2">
+                      <span className="text-[#31F5D4]" aria-hidden="true">
+                        ·
+                      </span>
+                      {item}
+                    </li>
+                  ))}
+                </ul>
+              </div>
+            </div>
+
+            <div className="mt-10">
+              <ResearchStrategyVisuals variant={section.visual} />
+            </div>
+
+            {"externalHref" in section && section.externalHref ? (
+              <a
+                href={section.externalHref}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="mt-8 inline-flex font-ui text-[11px] uppercase tracking-[0.12em] text-[#31F5D4] transition-colors hover:text-[#7CE7D6] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#31F5D4]"
+              >
+                {section.externalLabel} ↗
+              </a>
+            ) : null}
+          </section>
+        ))}
+
+        <section className="mt-20 border-t border-[rgba(255,255,255,0.08)] pt-16">
+          <h2 className="monolith-title monolith-title--card-sm">Why this work matters</h2>
+          <p className="mt-5 font-body text-[15px] leading-relaxed text-[#A8B3B0]">
+            This research supports the same principle behind my product work: make the system
+            legible before making it smart. Whether designing enterprise finance workflows or
+            AI-ready collaboration models, the goal is to create structures that help teams
+            understand, evaluate, and act with confidence.
+          </p>
+          <div className="mt-8 flex flex-wrap gap-4">
+            <Link
+              href="/#work"
+              className="inline-flex font-ui text-[11px] uppercase tracking-[0.12em] text-[#31F5D4] transition-colors hover:text-[#7CE7D6]"
+            >
+              Back to selected work →
+            </Link>
+            <Link
+              href="/#contact"
+              className="inline-flex font-ui text-[11px] uppercase tracking-[0.12em] text-[#A8B3B0] transition-colors hover:text-[#31F5D4]"
+            >
+              Get in touch →
+            </Link>
+          </div>
+        </section>
+      </article>
+    </main>
+  )
+}

--- a/components/ResearchStrategyVisuals.tsx
+++ b/components/ResearchStrategyVisuals.tsx
@@ -1,0 +1,202 @@
+/**
+ * Sanitized Research & Strategy visuals — abstract diagrams only.
+ * No screenshots, internal labels, logos, or confidential details.
+ */
+
+import type { ReactNode } from "react"
+
+function VisualBlurb({ children }: { children: ReactNode }) {
+  return <p className="research-visual__blurb">{children}</p>
+}
+
+export function ArchitecturesOfIntentModel() {
+  const stages = ["Feature layer", "Operating model", "Trust patterns", "Action systems"]
+  return (
+    <figure
+      className="research-visual research-visual--intent"
+      aria-labelledby="research-intent-title"
+    >
+      <figcaption id="research-intent-title" className="research-visual__caption">
+        Architectures of Intent model
+      </figcaption>
+      <VisualBlurb>
+        A public-safe diagram showing the shift from AI as feature layer to AI as operating model.
+      </VisualBlurb>
+      <svg
+        className="research-visual__svg"
+        viewBox="0 0 640 100"
+        role="img"
+        aria-label="Flow from feature layer through operating model and trust patterns to action systems"
+      >
+        <defs>
+          <linearGradient id="research-intent-grad" x1="0%" y1="0%" x2="100%" y2="0%">
+            <stop offset="0%" stopColor="#31F5D4" stopOpacity="0.35" />
+            <stop offset="50%" stopColor="#31F5D4" stopOpacity="0.85" />
+            <stop offset="100%" stopColor="#7CE7D6" stopOpacity="0.5" />
+          </linearGradient>
+        </defs>
+        <line
+          x1="24"
+          y1="44"
+          x2="616"
+          y2="44"
+          stroke="url(#research-intent-grad)"
+          strokeWidth="2"
+          strokeDasharray="6 8"
+        />
+        {stages.map((stage, i) => {
+          const x = 24 + i * 197
+          const isEnd = i === stages.length - 1
+          return (
+            <g key={stage}>
+              <circle
+                cx={x}
+                cy="44"
+                r={isEnd ? 12 : 10}
+                fill="#0B0F10"
+                stroke={isEnd ? "#FF7A66" : "#31F5D4"}
+                strokeWidth="1.5"
+                strokeOpacity={isEnd ? 0.65 : 0.55}
+              />
+              <text
+                x={x}
+                y="78"
+                textAnchor="middle"
+                fill="#A8B3B0"
+                fontSize="10"
+                fontFamily="var(--font-inter), system-ui, sans-serif"
+              >
+                {stage}
+              </text>
+            </g>
+          )
+        })}
+      </svg>
+    </figure>
+  )
+}
+
+export function GitHubCollaborationModel() {
+  const stages = [
+    "Workstreams",
+    "Shared foundations",
+    "PR review",
+    "Review artifact",
+    "Integrated prototype",
+  ]
+  return (
+    <figure
+      className="research-visual research-visual--github"
+      aria-labelledby="research-github-title"
+    >
+      <figcaption id="research-github-title" className="research-visual__caption">
+        GitHub collaboration operating model
+      </figcaption>
+      <VisualBlurb>
+        How multiple product workstreams can move through shared foundations, pull-request review,
+        review artifacts, and an integrated prototype.
+      </VisualBlurb>
+      <ol className="research-visual__pipeline" role="img" aria-label="Pipeline from workstreams through shared foundations, PR review, review artifact, to integrated prototype">
+        {stages.map((stage, i) => (
+          <li key={stage} className="research-visual__pipeline-step">
+            <span className="research-visual__pipeline-node" aria-hidden="true" />
+            <span className="research-visual__pipeline-label">{stage}</span>
+            {i < stages.length - 1 && (
+              <span className="research-visual__pipeline-connector" aria-hidden="true" />
+            )}
+          </li>
+        ))}
+      </ol>
+    </figure>
+  )
+}
+
+export function AiNativePlatformLoop() {
+  const stages = [
+    "Context",
+    "Grounding",
+    "Recommendation",
+    "Review",
+    "Action",
+    "Feedback",
+  ]
+  return (
+    <figure
+      className="research-visual research-visual--platform"
+      aria-labelledby="research-platform-title"
+    >
+      <figcaption id="research-platform-title" className="research-visual__caption">
+        AI-native platform pattern loop
+      </figcaption>
+      <VisualBlurb>
+        Context, grounding, recommendation, review, action, and feedback as a recurring trust
+        pattern for AI-native product experiences.
+      </VisualBlurb>
+      <svg
+        className="research-visual__svg research-visual__svg--loop"
+        viewBox="0 0 640 140"
+        role="img"
+        aria-label="Loop from context through grounding, recommendation, review, action, to feedback"
+      >
+        <defs>
+          <linearGradient id="research-loop-grad" x1="0%" y1="0%" x2="100%" y2="0%">
+            <stop offset="0%" stopColor="#31F5D4" stopOpacity="0.4" />
+            <stop offset="100%" stopColor="#7CE7D6" stopOpacity="0.7" />
+          </linearGradient>
+        </defs>
+        <path
+          d="M 32 70 Q 120 20, 220 35 T 420 35 T 608 70 T 420 105 T 220 105 T 32 70"
+          fill="none"
+          stroke="url(#research-loop-grad)"
+          strokeWidth="1.5"
+          strokeDasharray="5 7"
+          className="research-flow-line"
+        />
+        {stages.map((stage, i) => {
+          const angle = (i / stages.length) * Math.PI * 2 - Math.PI / 2
+          const cx = 320 + Math.cos(angle) * 200
+          const cy = 70 + Math.sin(angle) * 48
+          const isReview = stage === "Review"
+          return (
+            <g key={stage}>
+              <circle
+                cx={cx}
+                cy={cy}
+                r={isReview ? 11 : 9}
+                fill="#0B0F10"
+                stroke={isReview ? "#FF7A66" : "#31F5D4"}
+                strokeWidth="1.25"
+                strokeOpacity={isReview ? 0.7 : 0.5}
+              />
+              <text
+                x={cx}
+                y={cy + 22}
+                textAnchor="middle"
+                fill="#A8B3B0"
+                fontSize="9"
+                fontFamily="var(--font-inter), system-ui, sans-serif"
+              >
+                {stage}
+              </text>
+            </g>
+          )
+        })}
+      </svg>
+    </figure>
+  )
+}
+
+export default function ResearchStrategyVisuals({
+  variant,
+}: {
+  variant: "architectures-of-intent" | "github-design-collaboration" | "ai-native-platform-patterns"
+}) {
+  switch (variant) {
+    case "architectures-of-intent":
+      return <ArchitecturesOfIntentModel />
+    case "github-design-collaboration":
+      return <GitHubCollaborationModel />
+    case "ai-native-platform-patterns":
+      return <AiNativePlatformLoop />
+  }
+}

--- a/content/ask-ardavan.ts
+++ b/content/ask-ardavan.ts
@@ -18,6 +18,7 @@ export type AskArdavanPromptId =
   | "trustworthy-ai"
   | "ies"
   | "teams-bring-in"
+  | "research"
   | "founder"
   | "contact"
 
@@ -51,7 +52,7 @@ export const ASK_ARDAVAN_PROMPTS: AskArdavanPrompt[] = [
         href: "/work/quickbooks-dimensional-chart-of-accounts",
       },
     ],
-    suggestedNext: ["ies", "trustworthy-ai"],
+    suggestedNext: ["ies", "research"],
   },
   {
     id: "ai-native",
@@ -104,6 +105,25 @@ export const ASK_ARDAVAN_PROMPTS: AskArdavanPrompt[] = [
       },
     ],
     suggestedNext: ["ies", "contact"],
+  },
+  {
+    id: "research",
+    label: "What kind of research do you do?",
+    prompt: "What kind of research do you do?",
+    assistantTitle: "Research & Strategy",
+    answer:
+      "I create strategic research and operating models that help teams make sense of AI-native product work. Recent public-safe examples include an AI-native strategy guide, a GitHub-based collaboration model for integrated prototype work, and research on platform patterns like context, grounding, trust, review, permissions, human control, and moving from suggestion to action.",
+    links: [
+      {
+        label: "View Research & Strategy",
+        href: "/research",
+      },
+      {
+        label: "See how this connects to IES",
+        href: "/work/intuit-enterprise-suite",
+      },
+    ],
+    suggestedNext: ["teams-bring-in", "trustworthy-ai", "ies"],
   },
   {
     id: "founder",

--- a/content/research.ts
+++ b/content/research.ts
@@ -46,8 +46,6 @@ export const RESEARCH_ENTRIES: ResearchEntry[] = [
     status: "Public research artifact",
     href: "/research#architectures-of-intent",
     ctaLabel: "View research summary",
-    externalHref: "https://v0-ai-native-strategy-research.vercel.app/",
-    externalCtaLabel: "Open interactive guide",
   },
   {
     id: "github-design-collaboration",

--- a/content/research.ts
+++ b/content/research.ts
@@ -1,0 +1,94 @@
+/**
+ * Canonical public-safe source for Research & Strategy portfolio entries.
+ * No internal names, Drive links, metrics, or raw white paper text.
+ */
+
+export type ResearchEntry = {
+  id: string
+  title: string
+  eyebrow: string
+  summary: string
+  whatItShows: string
+  publicSafeThemes: string[]
+  status: string
+  href: string
+  ctaLabel: string
+  externalHref?: string
+  externalCtaLabel?: string
+}
+
+export const RESEARCH_SECTION = {
+  eyebrow: "Research & Strategy",
+  heading: "Operating models for AI-native design",
+  intro:
+    "I also create strategic research and frameworks that help teams make sense of AI-native product work — from shared prototype workflows to the trust patterns that make intelligent systems usable.",
+  ctaLabel: "View research summaries",
+  ctaHref: "/research",
+} as const
+
+export const RESEARCH_ENTRIES: ResearchEntry[] = [
+  {
+    id: "architectures-of-intent",
+    eyebrow: "AI-native strategy · Enterprise systems · Operating models",
+    title: "Architectures of Intent",
+    summary:
+      "A public AI-native strategy guide exploring what enterprise software becomes when AI stops being treated as a feature and starts becoming the operating model.",
+    whatItShows:
+      "AI-native product strategy, enterprise systems thinking, strategic storytelling, operating-model framing, and research synthesis.",
+    publicSafeThemes: [
+      "AI as operating model",
+      "Intelligence as infrastructure",
+      "Enterprise transformation",
+      "Strategic product framing",
+      "Systems thinking",
+      "Research synthesis",
+    ],
+    status: "Public research artifact",
+    href: "/research#architectures-of-intent",
+    ctaLabel: "View research summary",
+    externalHref: "https://v0-ai-native-strategy-research.vercel.app/",
+    externalCtaLabel: "Open interactive guide",
+  },
+  {
+    id: "github-design-collaboration",
+    eyebrow: "Design operating model · GitHub workflows · AI-ready collaboration",
+    title: "GitHub-Based Design Collaboration",
+    summary:
+      "Explored how design teams can use GitHub workflows, shared foundations, team-owned slices, generated route registries, pull-request review, and validation to bring multiple product workstreams into one integrated, AI-ready prototype model.",
+    whatItShows:
+      "Design operating-model thinking, design engineering fluency, cross-team workflow design, prototype governance, contribution systems, and automation-ready collaboration.",
+    publicSafeThemes: [
+      "Design operating models",
+      "Shared foundations",
+      "Team-owned slices",
+      "Pull-request review",
+      "Generated route registries",
+      "Review artifacts",
+      "AI-ready collaboration",
+    ],
+    status: "Public-safe research summary",
+    href: "/research#github-design-collaboration",
+    ctaLabel: "View research summary",
+  },
+  {
+    id: "ai-native-platform-patterns",
+    eyebrow: "AI-native platforms · Trust patterns · Decision architecture",
+    title: "AI-Native Platform Patterns",
+    summary:
+      "Synthesized recurring patterns across AI-native product experiences, including Observe → Act → Build modes, context, grounding, permissions, review, human control, and decision architecture.",
+    whatItShows:
+      "AI product strategy, research synthesis, pattern recognition, trust and governance thinking, and platform-level design judgment.",
+    publicSafeThemes: [
+      "Observe → Act → Build",
+      "Context and grounding",
+      "Trust and review",
+      "Permissions and governance",
+      "Human control",
+      "Suggestion-to-action workflows",
+      "Decision architecture",
+    ],
+    status: "Public-safe research summary",
+    href: "/research#ai-native-platform-patterns",
+    ctaLabel: "View research summary",
+  },
+]

--- a/docs/sot/changelog.md
+++ b/docs/sot/changelog.md
@@ -1,5 +1,16 @@
 # Portfolio Changelog (Sprint Docs)
 
+## 2026-07-11 — Sprint 8 — Research & Strategy Layer
+
+- Added public-safe SOT coverage for AI-native strategy research, GitHub-based design collaboration, and AI-native platform pattern research (`research-strategy-sot.md`)
+- Added `content/research.ts` canonical source for three research proof points
+- Added compact Research & Strategy homepage section (`#research-strategy`)
+- Added `/research` route with three public-safe research summaries and sanitized visuals
+- Added Ask Ardavan research prompt (“What kind of research do you do?”)
+- Updated roadmap, claims log, and sanitized visual plan
+- Preserved guardrails around private feedback, internal documents, internal names, screenshots, and unverified claims
+- No résumé PDF, CNAME, deploy workflow, dependency, or case-study body changes
+
 ## 2026-07-11 — Share preview metadata fix
 
 - Added `public/og-image.jpg` (1200×630 JPEG) as primary `og:image` for share crawlers; kept PNG as secondary fallback

--- a/docs/sot/portfolio-claims-log.md
+++ b/docs/sot/portfolio-claims-log.md
@@ -1,7 +1,7 @@
 # Portfolio Claims Log
 
-Version: 1.7  
-Last updated: 2026-07-10  
+Version: 1.8  
+Last updated: 2026-07-11  
 Status: Public-safe
 
 | Claim | Status | Public wording | Notes |
@@ -43,3 +43,9 @@ Status: Public-safe
 | IES case study can describe future-state exploration. | PUBLIC_SAFE when abstracted | Helped make future-state product direction easier to understand, discuss, and evaluate through frameworks, prototypes, and leadership-ready narratives. | Do not name exact teams, product acronyms, executive audiences, event names, prototype names, or roadmap details. |
 | IES case study can describe framework transfer. | PUBLIC_SAFE when abstracted / VERIFY for specifics | Translated core AI-native experience concepts into reusable patterns that could be explored across related enterprise product contexts. | Do not name adjacent product area until approved. |
 | IES case study can describe executive-facing prototype/storytelling work. | PUBLIC_SAFE when abstracted / PRIVATE_CONTEXT for details | Used functional prototypes and polished artifacts to make abstract product direction easier for teams to understand, critique, and refine. | Do not name exact demo context, executives, or internal event names. |
+| Ardavan created a public AI-native strategy guide. | PUBLIC_SAFE if the v0 site is approved for linking | Created a public AI-native strategy guide exploring what enterprise software becomes when AI shifts from feature layer to operating model. | Verify whether to link to the current v0 URL or migrate/sanitize into the portfolio. |
+| Ardavan created or wrote a white paper about GitHub-based design collaboration. | PRIVATE_CONTEXT / VERIFY | Explored how GitHub-based workflows can help design teams bring multiple product workstreams into one integrated, AI-ready prototype model. | Do not name internal reviewers or publish raw white paper text without approval. |
+| Design leadership found the GitHub collaboration research useful. | PRIVATE_CONTEXT / VERIFY | Used to help frame team conversations around AI-ready design workflows. | Do not name individuals or quote feedback without approval. |
+| Ardavan researches AI-native platform patterns. | PUBLIC_SAFE when abstracted | Synthesized AI-native platform patterns around Observe → Act → Build, context, grounding, trust, review, permissions, human control, and moving from suggestion to action. | Keep public wording at pattern/research level unless specific artifacts are approved. |
+| Research work demonstrates design operating-model thinking. | PUBLIC_SAFE | Creates strategic research and operating models that help teams design, prototype, and govern AI-native product work. | Useful for Research & Strategy section. |
+| Research work drove adoption, automation impact, or measurable productivity gains. | DO_NOT_PUBLISH unless verified | Do not use. | No unverified metrics or outcome claims. |

--- a/docs/sot/portfolio-roadmap.md
+++ b/docs/sot/portfolio-roadmap.md
@@ -1,6 +1,6 @@
 # Portfolio Roadmap
 
-Version: 1.7  
+Version: 1.8  
 Last updated: 2026-07-11  
 Status: Public-safe
 
@@ -14,6 +14,7 @@ Status: Public-safe
 - QBOA public-safe case study is live at `/work/quickbooks-dimensional-chart-of-accounts` (visual polish in Sprint 6)
 - OG image, favicon, and share metadata are live (Sprint 3.2)
 - Executive storytelling proof layer homepage section is live (Sprint 4)
+- Research & Strategy layer in progress (Sprint 8)
 
 ## Priority order
 
@@ -139,6 +140,33 @@ Still deferred:
 - Manual LinkedIn / Slack / iMessage unfurl validation (steps documented for Ardavan)
 - Route-specific OG images (optional)
 - Apex domain redirect verification outside repo
+
+## Sprint 8 — Research & Strategy Layer: AI-native operating models
+
+**Priority:** P1 after launch polish and two flagship case studies.
+
+**Rationale:**  
+The portfolio already has product case-study depth through IES and QBOA. The next strategic layer should show Ardavan's research, operating-model thinking, and AI-native design strategy without adding too many full case studies.
+
+**Deliverables:**
+
+- Research & Strategy SOT (`research-strategy-sot.md`)
+- Research claims log entries
+- `content/research.ts` source
+- Compact homepage Research & Strategy section
+- `/research` route
+- Ask Ardavan research prompt
+- Sanitized research visual direction
+- Changelog update
+
+**Future backlog:**
+
+- P2 — GitHub-Based Design Collaboration detail page
+- P2 — AI-Native Platform Patterns detail page / pattern library
+- P2 — Architectures of Intent deeper page or external link
+- P2 — Research artifact visuals
+- P3 — Publish excerpts only if approved
+- P3 — Add research links to résumé only if verified and relevant
 
 ## Next sprint candidate — Portfolio maintenance
 

--- a/docs/sot/research-strategy-sot.md
+++ b/docs/sot/research-strategy-sot.md
@@ -1,0 +1,142 @@
+# Research & Strategy SOT — Public-Safe Backlog
+
+Version: 1.0  
+Last updated: 2026-07-11  
+Status: Public-safe
+
+## Purpose
+
+Document public-safe portfolio opportunities around Ardavan's strategic research work, including AI-native strategy, GitHub-based design collaboration, AI-native platform modes, and decision architecture.
+
+## Summary
+
+Ardavan's Research & Strategy work extends beyond product screens into how teams design, prototype, govern, and scale AI-native product work. This includes a public AI-native strategy guide, a GitHub-based collaboration model for shared release prototypes, and research into AI-native platform patterns such as Observe → Act → Build, context, grounding, trust, review, permissions, human control, and decision architecture. This material should support the portfolio as a Research & Strategy layer, not replace the primary IES/QBOA case studies.
+
+## 1. Why this matters
+
+This work shows Ardavan contributing to the operating models, frameworks, and research patterns that help design teams adapt to AI-native product development. It strengthens the portfolio narrative around systems thinking, design strategy, design engineering fluency, research synthesis, and organizational influence.
+
+## 2. Public-safe research tracks
+
+### Track 1: Architectures of Intent
+
+**Public-safe summary:**  
+A public AI-native strategy guide exploring what enterprise software becomes when AI stops being treated as a feature and starts becoming the operating model.
+
+**What it proves:**
+
+- AI-native product strategy
+- Enterprise systems thinking
+- Strategic storytelling
+- Operating-model framing
+- Research synthesis
+- Executive-ready narrative craft
+
+**Potential artifacts:**
+
+- Operating model diagram
+- Intelligence-as-infrastructure map
+- “Feature → operating model” transition model
+- Architecture-of-intent visual
+
+### Track 2: GitHub-Based Design Collaboration
+
+**Public-safe summary:**  
+Explored how design teams can use GitHub workflows, shared components, pull requests, review artifacts, and contribution governance to bring multiple product workstreams into one integrated, AI-ready prototype model.
+
+**What it proves:**
+
+- Design operating-model thinking
+- Design engineering fluency
+- Cross-team workflow design
+- Prototype governance
+- Contribution systems
+- Automation-ready collaboration
+- AI-ready contribution workflow design
+
+**Potential artifacts:**
+
+- Operating model diagram
+- Contribution workflow map
+- Shared shell / team-owned slices model
+- Generated route registry diagram
+- Pull request review flow
+- Review artifact lifecycle
+- AI-assisted contribution rails
+
+### Track 3: AI-Native Platform Patterns
+
+**Public-safe summary:**  
+Synthesized recurring patterns across AI-native product experiences, including platform modes, context, grounding, trust, permissions, review, human control, uncertainty handling, and moving from suggestion to action.
+
+**What it proves:**
+
+- AI product strategy
+- Platform-level research
+- Pattern recognition
+- Trust and governance thinking
+- Decision architecture
+- Product framing for complex AI systems
+
+**Potential artifacts:**
+
+- Observe → Act → Build model
+- Context → grounding → recommendation → review → action loop
+- Autonomy-tier model
+- Human-control checkpoint model
+- Trust and governance pattern library
+
+## 3. Recommended public hierarchy
+
+**Homepage:**  
+Compact Research & Strategy section with three cards.
+
+**Research route:**  
+`/research` with three public-safe summaries:
+
+- Architectures of Intent
+- GitHub-Based Design Collaboration
+- AI-Native Platform Patterns
+
+**Future route candidates:**
+
+- `/research/github-design-collaboration`
+- `/research/ai-native-platform-patterns`
+- `/research/architectures-of-intent`
+
+## 4. Public-safe wording candidates
+
+- “I create strategic research and operating models that help teams design, prototype, and govern AI-native product work.”
+- “Explored how GitHub-based workflows can help design teams bring multiple product workstreams into one integrated, AI-ready prototype model.”
+- “Synthesized AI-native platform patterns around context, grounding, trust, review, permissions, human control, and moving from suggestion to action.”
+- “My research work helps teams make the operating model behind AI-native product development more legible.”
+- “Mapped AI-native software patterns from feature-layer assistance toward operating-model change.”
+
+## 5. Do not publish without approval
+
+- Internal feedback from named colleagues
+- Exact internal audience
+- Raw white paper text
+- Internal screenshots
+- Internal docs
+- Internal repo names
+- Internal team names
+- Private comments
+- Exact outcomes or decisions
+- Metrics
+- Launch/adoption/revenue claims
+- Drive folder links
+
+## 6. Open verification questions
+
+- Can the public v0 research site be linked directly from the portfolio?
+- Should the v0 site be embedded, linked, or migrated into `/research` later?
+- Can the GitHub collaboration white paper title be named publicly?
+- Can any excerpts be published?
+- Can the research be described as a white paper publicly?
+- Can design leadership feedback be referenced abstractly?
+- Which diagrams can be recreated safely?
+- Can any internal workflow examples be generalized?
+- Should the AI-native platform research become a public article, pattern library, or research page?
+- Which research artifacts can be shown publicly?
+- Are there any approved outcomes or uses that can be stated without overclaiming?

--- a/docs/sot/sanitized-visual-plan.md
+++ b/docs/sot/sanitized-visual-plan.md
@@ -1,7 +1,7 @@
 # Sanitized Visual Plan
 
-Version: 1.4  
-Last updated: 2026-07-10  
+Version: 1.5  
+Last updated: 2026-07-11  
 Status: Public-safe
 
 ## Purpose
@@ -98,3 +98,31 @@ See `docs/sot/executive-storytelling-and-future-prototypes-sot.md`.
 - Do not use real deck screenshots
 - Do not use real demo scripts
 - Do not imply launch, adoption, or business impact
+
+## Research & Strategy visuals (Sprint 8 — implemented)
+
+Implemented in `components/ResearchStrategyVisuals.tsx`:
+
+1. **Architectures of Intent model**  
+   A public-safe diagram showing the shift from AI as feature layer to AI as operating model.  
+   Labels: Feature layer → Operating model → Trust patterns → Action systems
+
+2. **GitHub collaboration operating model**  
+   A public-safe diagram showing how multiple product workstreams can move through shared foundations, pull-request review, review artifacts, and integrated prototype.  
+   Labels: Workstreams → Shared foundations → PR review → Review artifact → Integrated prototype
+
+3. **AI-native platform pattern loop**  
+   A public-safe diagram showing context, grounding, recommendation, review, action, and feedback.  
+   Labels: Context → Grounding → Recommendation → Review → Action → Feedback
+
+4. **Contribution governance model** (future)  
+   A future visual showing team-owned contributions, review checkpoints, and stable demo/release outputs.
+
+### Rules for research visuals
+
+- Synthetic labels only
+- No screenshots
+- No private docs
+- No internal repo names
+- No internal team names
+- No metrics


### PR DESCRIPTION
## Summary
Adds a public-safe Research & Strategy layer for AI-native strategy, GitHub-based design collaboration, and AI-native platform pattern research.

## Included
- Research & Strategy SOT
- Research claims log entries
- content/research.ts
- Homepage Research & Strategy section
- /research route with three public-safe research summaries
- Ask Ardavan research prompt
- Sanitized research visuals
- Roadmap/changelog updates

## Safety
- No raw white paper text
- No private feedback names
- No raw Drive links in public pages
- No confidential screenshots
- No internal repo names
- No internal team names
- No metrics
- No launch/adoption/revenue claims
- No unsupported ownership/impact verbs
- No résumé PDF changes
- No deployment changes
- No dependencies
- No unrelated OG-image/share-preview changes

## QA
- pnpm build passed

Made with [Cursor](https://cursor.com)