### PR TITLE
Publish Architectures of Intent research

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -1609,3 +1609,503 @@ img {
     animation: none !important;
   }
 }
+
+/* ── Architectures of Intent research article ── */
+
+.aoi-page {
+  --aoi-column: min(100%, 44rem);
+}
+
+.aoi-toc {
+  align-self: start;
+}
+
+.aoi-toc__heading {
+  font-family: var(--font-ui, ui-sans-serif, system-ui, sans-serif);
+  font-size: 11px;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: #f4f7f6;
+  margin-bottom: 0.85rem;
+}
+
+.aoi-toc__list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: grid;
+  gap: 0.45rem;
+}
+
+.aoi-toc__link {
+  font-family: var(--font-body, Georgia, "Times New Roman", serif);
+  font-size: 13px;
+  line-height: 1.45;
+  color: #a8b3b0;
+  text-decoration: none;
+  transition: color 0.2s ease;
+}
+
+.aoi-toc__link:hover,
+.aoi-toc__link:focus-visible {
+  color: #31f5d4;
+}
+
+.aoi-toc__link:focus-visible {
+  outline: none;
+  box-shadow: 0 0 0 2px #31f5d4;
+}
+
+@media (min-width: 1024px) {
+  .aoi-toc {
+    position: sticky;
+    top: 5.5rem;
+    max-height: calc(100vh - 6.5rem);
+    overflow-y: auto;
+  }
+}
+
+.aoi-column {
+  max-width: var(--aoi-column);
+}
+
+.aoi-abstract {
+  font-family: var(--font-body, Georgia, "Times New Roman", serif);
+  font-size: 1.05rem;
+  line-height: 1.75;
+  color: #d7ddd9;
+  border-left: 2px solid rgba(49, 245, 212, 0.45);
+  padding-left: 1rem;
+}
+
+.aoi-section {
+  scroll-margin-top: 5.5rem;
+  margin-top: 3.25rem;
+  padding-top: 0.25rem;
+}
+
+.aoi-section:first-of-type {
+  margin-top: 0;
+}
+
+.aoi-section__title {
+  font-family: var(--font-display, ui-sans-serif, system-ui, sans-serif);
+  font-size: clamp(1.35rem, 2.2vw, 1.75rem);
+  font-weight: 500;
+  letter-spacing: -0.02em;
+  color: #f4f7f6;
+  margin-bottom: 1.25rem;
+}
+
+.aoi-section__p {
+  font-family: var(--font-body, Georgia, "Times New Roman", serif);
+  font-size: 1.05rem;
+  line-height: 1.8;
+  color: #a8b3b0;
+  margin-top: 1.15rem;
+  overflow-wrap: anywhere;
+}
+
+.aoi-section__note {
+  font-style: italic;
+  color: #9aa6a2;
+}
+
+.aoi-section__visual {
+  margin-top: 1.75rem;
+  margin-bottom: 0.5rem;
+}
+
+.aoi-cite {
+  font-size: 0.7em;
+  line-height: 0;
+  margin-left: 0.1em;
+}
+
+.aoi-cite__link {
+  color: #31f5d4;
+  text-decoration: none;
+  font-family: var(--font-ui, ui-sans-serif, system-ui, sans-serif);
+  padding: 0 0.1em;
+}
+
+.aoi-cite__link:hover,
+.aoi-cite__link:focus-visible {
+  color: #7ce7d6;
+  text-decoration: underline;
+}
+
+.aoi-cite__link:focus-visible {
+  outline: none;
+  box-shadow: 0 0 0 2px #31f5d4;
+}
+
+.aoi-principles {
+  list-style: none;
+  margin: 1.5rem 0 0;
+  padding: 0;
+  display: grid;
+  gap: 1rem;
+}
+
+@media (min-width: 720px) {
+  .aoi-principles {
+    grid-template-columns: 1fr 1fr;
+    gap: 1.15rem 1.5rem;
+  }
+}
+
+.aoi-principles__item {
+  display: grid;
+  grid-template-columns: auto 1fr;
+  gap: 0.75rem;
+  font-family: var(--font-body, Georgia, "Times New Roman", serif);
+  font-size: 0.98rem;
+  line-height: 1.65;
+  color: #a8b3b0;
+  padding: 0.85rem 0;
+  border-top: 1px solid rgba(255, 255, 255, 0.08);
+}
+
+.aoi-principles__number {
+  font-family: var(--font-mono, ui-monospace, monospace);
+  font-size: 11px;
+  letter-spacing: 0.08em;
+  color: #31f5d4;
+  padding-top: 0.2rem;
+}
+
+.aoi-sources {
+  list-style: none;
+  margin: 1.5rem 0 0;
+  padding: 0;
+  display: grid;
+  gap: 1.15rem;
+  counter-reset: none;
+}
+
+.aoi-sources__item {
+  display: grid;
+  grid-template-columns: auto 1fr;
+  gap: 0.65rem;
+  scroll-margin-top: 5.5rem;
+  font-family: var(--font-body, Georgia, "Times New Roman", serif);
+  font-size: 0.95rem;
+  line-height: 1.65;
+  color: #a8b3b0;
+}
+
+.aoi-sources__index {
+  font-family: var(--font-mono, ui-monospace, monospace);
+  font-size: 12px;
+  color: #7ce7d6;
+  padding-top: 0.15rem;
+}
+
+.aoi-sources__body {
+  min-width: 0;
+  overflow-wrap: anywhere;
+}
+
+.aoi-sources__link {
+  color: #31f5d4;
+  text-decoration: underline;
+  text-underline-offset: 0.15em;
+}
+
+.aoi-sources__link:hover,
+.aoi-sources__link:focus-visible {
+  color: #7ce7d6;
+}
+
+.aoi-sources__link:focus-visible {
+  outline: none;
+  box-shadow: 0 0 0 2px #31f5d4;
+}
+
+.aoi-sources__publisher {
+  color: #9aa6a2;
+}
+
+.aoi-sources__back {
+  display: inline-block;
+  margin-top: 0.25rem;
+  font-family: var(--font-ui, ui-sans-serif, system-ui, sans-serif);
+  font-size: 11px;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  color: #a8b3b0;
+  text-decoration: none;
+}
+
+.aoi-sources__back:hover,
+.aoi-sources__back:focus-visible {
+  color: #31f5d4;
+}
+
+.aoi-related {
+  margin-top: 4rem;
+  padding-top: 2.5rem;
+  border-top: 1px solid rgba(255, 255, 255, 0.08);
+}
+
+.aoi-related__grid {
+  display: grid;
+  gap: 2rem;
+  margin-top: 1.25rem;
+}
+
+@media (min-width: 720px) {
+  .aoi-related__grid {
+    grid-template-columns: 1fr 1fr;
+  }
+}
+
+.aoi-related__label {
+  font-family: var(--font-ui, ui-sans-serif, system-ui, sans-serif);
+  font-size: 11px;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: #f4f7f6;
+  margin-bottom: 0.75rem;
+}
+
+.aoi-related__list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: 0.55rem;
+}
+
+.aoi-related__list a {
+  color: #31f5d4;
+  text-decoration: none;
+  font-family: var(--font-body, Georgia, "Times New Roman", serif);
+  font-size: 0.98rem;
+}
+
+.aoi-related__list a:hover,
+.aoi-related__list a:focus-visible {
+  color: #7ce7d6;
+  text-decoration: underline;
+}
+
+.aoi-related__note {
+  margin-top: 0.9rem;
+  font-family: var(--font-body, Georgia, "Times New Roman", serif);
+  font-size: 0.92rem;
+  line-height: 1.65;
+  color: #9aa6a2;
+}
+
+.aoi-closing {
+  margin-top: 3.5rem;
+  padding-top: 2rem;
+  border-top: 1px solid rgba(255, 255, 255, 0.08);
+  padding-bottom: 5rem;
+}
+
+.aoi-closing__copy {
+  font-family: var(--font-body, Georgia, "Times New Roman", serif);
+  font-size: 1.1rem;
+  line-height: 1.6;
+  color: #d7ddd9;
+}
+
+/* Visuals */
+
+.aoi-visual {
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  background: rgba(11, 15, 16, 0.75);
+  padding: 1.25rem 1.15rem 1.35rem;
+}
+
+.aoi-visual__caption {
+  font-family: var(--font-ui, ui-sans-serif, system-ui, sans-serif);
+  font-size: 11px;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: #f4f7f6;
+}
+
+.aoi-visual__blurb {
+  margin-top: 0.55rem;
+  font-family: var(--font-body, Georgia, "Times New Roman", serif);
+  font-size: 0.92rem;
+  line-height: 1.55;
+  color: #a8b3b0;
+}
+
+.aoi-visual__sr-list {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
+.aoi-visual__spectrum {
+  margin-top: 1.25rem;
+  display: grid;
+  gap: 1.25rem;
+}
+
+@media (min-width: 768px) {
+  .aoi-visual__spectrum {
+    grid-template-columns: repeat(3, 1fr);
+    gap: 1rem;
+  }
+}
+
+.aoi-visual__spectrum-stage {
+  text-align: center;
+}
+
+.aoi-visual__shapes {
+  width: 100%;
+  max-width: 10rem;
+  height: auto;
+  margin: 0 auto;
+  display: block;
+}
+
+.aoi-visual__stage-label {
+  margin-top: 0.65rem;
+  font-family: var(--font-ui, ui-sans-serif, system-ui, sans-serif);
+  font-size: 12px;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: #f4f7f6;
+}
+
+.aoi-visual__stage-sub {
+  margin-top: 0.25rem;
+  font-family: var(--font-body, Georgia, "Times New Roman", serif);
+  font-size: 0.85rem;
+  color: #a8b3b0;
+}
+
+.aoi-visual__archetypes {
+  margin-top: 1.25rem;
+}
+
+.aoi-visual__archetype-center {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 3.5rem;
+  margin-bottom: 1rem;
+  border: 1px solid rgba(49, 245, 212, 0.45);
+  background: rgba(49, 245, 212, 0.08);
+  font-family: var(--font-ui, ui-sans-serif, system-ui, sans-serif);
+  font-size: 12px;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  color: #7ce7d6;
+  text-align: center;
+  padding: 0.75rem;
+}
+
+.aoi-visual__archetype-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: 0.75rem;
+}
+
+@media (min-width: 900px) {
+  .aoi-visual__archetype-list {
+    grid-template-columns: 1fr 1fr;
+  }
+}
+
+.aoi-visual__archetype-item {
+  border-top: 1px solid rgba(255, 255, 255, 0.08);
+  padding-top: 0.7rem;
+  display: grid;
+  gap: 0.25rem;
+}
+
+.aoi-visual__archetype-item strong {
+  font-family: var(--font-ui, ui-sans-serif, system-ui, sans-serif);
+  font-size: 12px;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: #f4f7f6;
+  font-weight: 500;
+}
+
+.aoi-visual__archetype-item span {
+  font-family: var(--font-body, Georgia, "Times New Roman", serif);
+  font-size: 0.9rem;
+  line-height: 1.5;
+  color: #a8b3b0;
+}
+
+.aoi-visual__loop {
+  list-style: none;
+  margin: 1.25rem 0 0;
+  padding: 0;
+  display: grid;
+  gap: 0.65rem;
+}
+
+@media (min-width: 900px) {
+  .aoi-visual__loop {
+    grid-template-columns: repeat(4, minmax(0, 1fr));
+    gap: 0.75rem;
+  }
+}
+
+.aoi-visual__loop-step {
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  background: rgba(255, 255, 255, 0.02);
+  padding: 0.75rem 0.7rem;
+  display: grid;
+  gap: 0.35rem;
+}
+
+.aoi-visual__loop-step--review {
+  border-color: rgba(255, 122, 102, 0.65);
+  background: rgba(255, 122, 102, 0.08);
+}
+
+.aoi-visual__loop-index {
+  font-family: var(--font-mono, ui-monospace, monospace);
+  font-size: 10px;
+  letter-spacing: 0.08em;
+  color: #7ce7d6;
+}
+
+.aoi-visual__loop-step--review .aoi-visual__loop-index {
+  color: #ff7a66;
+}
+
+.aoi-visual__loop-label {
+  font-family: var(--font-ui, ui-sans-serif, system-ui, sans-serif);
+  font-size: 12px;
+  line-height: 1.4;
+  color: #f4f7f6;
+}
+
+.aoi-visual__loop-arrow,
+.aoi-visual__loop-return {
+  font-family: var(--font-body, Georgia, "Times New Roman", serif);
+  font-size: 0.8rem;
+  color: #a8b3b0;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .aoi-toc__link,
+  .aoi-cite__link,
+  .aoi-sources__link,
+  .aoi-related__list a {
+    transition: none;
+  }
+}

--- a/app/research/ai-native-strategy/page.tsx
+++ b/app/research/ai-native-strategy/page.tsx
@@ -1,0 +1,262 @@
+import type { Metadata } from "next"
+import Link from "next/link"
+import type { ReactNode } from "react"
+import ArchitecturesOfIntentVisuals from "@/components/ArchitecturesOfIntentVisuals"
+import IALogotype from "@/components/ia-logotype"
+import {
+  ARCHITECTURES_OF_INTENT_META,
+  ARCHITECTURES_OF_INTENT_PRINCIPLES,
+  ARCHITECTURES_OF_INTENT_SECTIONS,
+  ARCHITECTURES_OF_INTENT_TOC,
+} from "@/content/architectures-of-intent"
+import {
+  ARCHITECTURES_OF_INTENT_PUBLICATION_NOTE,
+  ARCHITECTURES_OF_INTENT_SOURCES,
+} from "@/content/architectures-of-intent-sources"
+import { openGraphShareImages, SITE_URL, twitterShareImages } from "@/lib/site"
+
+const PAGE_PATH = "/research/ai-native-strategy"
+const PAGE_TITLE = "Architectures of Intent — Ardavan Mirhosseini"
+const PAGE_DESCRIPTION =
+  "A research essay on designing enterprise software when AI becomes the operating model—across context, grounding, evidence, human review, permissions, and governed action."
+
+const ogImageAlt =
+  "Ardavan Mirhosseini — Architectures of Intent research on AI-native enterprise product strategy."
+
+export const metadata: Metadata = {
+  title: PAGE_TITLE,
+  description: PAGE_DESCRIPTION,
+  alternates: {
+    canonical: PAGE_PATH,
+  },
+  openGraph: {
+    title: PAGE_TITLE,
+    description: PAGE_DESCRIPTION,
+    url: `${SITE_URL}${PAGE_PATH}`,
+    type: "article",
+    siteName: "Ardavan Mirhosseini",
+    images: openGraphShareImages(ogImageAlt),
+  },
+  twitter: {
+    card: "summary_large_image",
+    title: PAGE_TITLE,
+    description: PAGE_DESCRIPTION,
+    images: twitterShareImages,
+  },
+}
+
+function renderCitedText(text: string): ReactNode[] {
+  const parts = text.split(/(\{\{\d+\}\})/g)
+  return parts.map((part, index) => {
+    const match = part.match(/^\{\{(\d+)\}\}$/)
+    if (!match) return <span key={`t-${index}`}>{part}</span>
+    const n = Number(match[1])
+    return (
+      <sup key={`c-${index}-${n}`} className="aoi-cite">
+        <a
+          href={`#source-${n}`}
+          id={`cite-ref-${n}-${index}`}
+          className="aoi-cite__link"
+          aria-label={`Source ${n}`}
+        >
+          {n}
+        </a>
+      </sup>
+    )
+  })
+}
+
+export default function ArchitecturesOfIntentPage() {
+  return (
+    <main className="aoi-page min-h-screen overflow-x-hidden bg-[#05070A] text-[#F4F7F6]">
+      <header className="border-b border-[rgba(255,255,255,0.08)] bg-[#05070A]/90 backdrop-blur-md">
+        <div className="mx-auto flex h-16 max-w-[1120px] items-center justify-between px-6 lg:px-8">
+          <IALogotype />
+          <Link
+            href="/research"
+            className="font-mono text-xs uppercase tracking-[0.16em] text-[#A8B3B0] transition-colors hover:text-[#31F5D4] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#31F5D4]"
+          >
+            Back to Research &amp; Strategy
+          </Link>
+        </div>
+      </header>
+
+      <div className="aoi-shell mx-auto grid max-w-[1120px] gap-10 px-6 py-14 lg:grid-cols-[220px_minmax(0,1fr)] lg:gap-14 lg:px-8 lg:py-20">
+        <nav className="aoi-toc" aria-label="On this page">
+          <p className="aoi-toc__heading">On this page</p>
+          <ol className="aoi-toc__list">
+            {ARCHITECTURES_OF_INTENT_TOC.map((item) => (
+              <li key={item.id}>
+                <a href={`#${item.id}`} className="aoi-toc__link">
+                  {item.label}
+                </a>
+              </li>
+            ))}
+          </ol>
+        </nav>
+
+        <div className="aoi-column min-w-0">
+          <header className="aoi-hero">
+            <p className="font-mono text-xs uppercase tracking-[0.16em] text-[#7CE7D6]">
+              {ARCHITECTURES_OF_INTENT_META.eyebrow}
+            </p>
+            <h1 className="monolith-title monolith-title--section mt-4">
+              {ARCHITECTURES_OF_INTENT_META.title}
+            </h1>
+            <p className="mt-5 font-body text-lg leading-relaxed text-[#A8B3B0] sm:text-xl">
+              {ARCHITECTURES_OF_INTENT_META.subtitle}
+            </p>
+            <p className="mt-4 font-ui text-[12px] uppercase tracking-[0.12em] text-[#7CE7D6]/90">
+              {ARCHITECTURES_OF_INTENT_META.metadataLine}
+            </p>
+            <p className="aoi-abstract mt-8">{ARCHITECTURES_OF_INTENT_META.abstract}</p>
+            <div className="mt-8 flex flex-wrap gap-4">
+              <a href="#opening-thesis" className="case-study-cta case-study-cta--primary">
+                Begin reading
+              </a>
+              <a
+                href={ARCHITECTURES_OF_INTENT_META.interactiveGuideHref}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="case-study-cta case-study-cta--secondary"
+              >
+                {ARCHITECTURES_OF_INTENT_META.interactiveGuideLabel}{" "}
+                <span aria-hidden="true">↗</span>
+                <span className="sr-only"> (opens in a new tab)</span>
+              </a>
+            </div>
+          </header>
+
+          <article className="aoi-article mt-16">
+            {ARCHITECTURES_OF_INTENT_SECTIONS.map((section) => (
+              <section key={section.id} id={section.id} className="aoi-section">
+                <h2 className="aoi-section__title">{section.title}</h2>
+                {section.blocks.map((block, blockIndex) => {
+                  if (block.type === "p") {
+                    return (
+                      <p key={`${section.id}-p-${blockIndex}`} className="aoi-section__p">
+                        {renderCitedText(block.text)}
+                      </p>
+                    )
+                  }
+                  if (block.type === "visual") {
+                    return (
+                      <div key={`${section.id}-v-${block.variant}`} className="aoi-section__visual">
+                        <ArchitecturesOfIntentVisuals variant={block.variant} />
+                      </div>
+                    )
+                  }
+                  return (
+                    <ol key={`${section.id}-principles`} className="aoi-principles">
+                      {ARCHITECTURES_OF_INTENT_PRINCIPLES.map((principle, i) => (
+                        <li key={principle.slice(0, 32)} className="aoi-principles__item">
+                          <span className="aoi-principles__number" aria-hidden="true">
+                            {i + 1}
+                          </span>
+                          <span>{principle}</span>
+                        </li>
+                      ))}
+                    </ol>
+                  )
+                })}
+              </section>
+            ))}
+
+            <section id="sources" className="aoi-section">
+              <h2 className="aoi-section__title">Sources and further reading</h2>
+              <p className="aoi-section__p aoi-section__note">
+                {ARCHITECTURES_OF_INTENT_PUBLICATION_NOTE}
+              </p>
+              <ol className="aoi-sources">
+                {ARCHITECTURES_OF_INTENT_SOURCES.map((source) => (
+                  <li key={source.id} id={source.id} className="aoi-sources__item">
+                    <span className="aoi-sources__index">{source.number}.</span>
+                    <div className="aoi-sources__body">
+                      {source.links.map((link, i) => (
+                        <span key={link.href}>
+                          {i > 0 ? " and " : null}
+                          <a
+                            href={link.href}
+                            target="_blank"
+                            rel="noopener noreferrer"
+                            className="aoi-sources__link"
+                          >
+                            {link.label}
+                            <span aria-hidden="true"> ↗</span>
+                            <span className="sr-only"> (opens in a new tab)</span>
+                          </a>
+                        </span>
+                      ))}
+                      <span className="aoi-sources__publisher">, {source.publisher}.</span>{" "}
+                      <a href="#opening-thesis" className="aoi-sources__back">
+                        Back to article
+                      </a>
+                    </div>
+                  </li>
+                ))}
+              </ol>
+            </section>
+          </article>
+
+          <section className="aoi-related" aria-labelledby="aoi-related-heading">
+            <h2 id="aoi-related-heading" className="aoi-section__title">
+              Related work
+            </h2>
+            <div className="aoi-related__grid">
+              <div>
+                <h3 className="aoi-related__label">Related research</h3>
+                <ul className="aoi-related__list">
+                  <li>
+                    <Link href="/research">Research &amp; Strategy</Link>
+                  </li>
+                  <li>
+                    <Link href="/research#ai-native-platform-patterns">
+                      AI-Native Platform Patterns
+                    </Link>
+                  </li>
+                  <li>
+                    <a
+                      href={ARCHITECTURES_OF_INTENT_META.interactiveGuideHref}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                    >
+                      Open interactive guide{" "}
+                      <span aria-hidden="true">↗</span>
+                      <span className="sr-only"> (opens in a new tab)</span>
+                    </a>
+                  </li>
+                </ul>
+              </div>
+              <div>
+                <h3 className="aoi-related__label">Related product work</h3>
+                <ul className="aoi-related__list">
+                  <li>
+                    <Link href="/work/intuit-enterprise-suite">Intuit Enterprise Suite</Link>
+                  </li>
+                </ul>
+                <p className="aoi-related__note">
+                  This research and the IES case study share a focus on making complex systems
+                  legible through evidence, trust, review, and human judgment.
+                </p>
+              </div>
+            </div>
+          </section>
+
+          <footer className="aoi-closing">
+            <p className="aoi-closing__copy">
+              Make the system legible before making it smart.
+            </p>
+            <div className="mt-6 flex flex-wrap gap-4">
+              <Link href="/research" className="case-study-cta case-study-cta--secondary">
+                Back to Research &amp; Strategy
+              </Link>
+              <Link href="/#contact" className="case-study-cta case-study-cta--primary">
+                Get in touch
+              </Link>
+            </div>
+          </footer>
+        </div>
+      </div>
+    </main>
+  )
+}

--- a/app/research/ai-native-strategy/page.tsx
+++ b/app/research/ai-native-strategy/page.tsx
@@ -110,21 +110,6 @@ export default function ArchitecturesOfIntentPage() {
               {ARCHITECTURES_OF_INTENT_META.metadataLine}
             </p>
             <p className="aoi-abstract mt-8">{ARCHITECTURES_OF_INTENT_META.abstract}</p>
-            <div className="mt-8 flex flex-wrap gap-4">
-              <a href="#opening-thesis" className="case-study-cta case-study-cta--primary">
-                Begin reading
-              </a>
-              <a
-                href={ARCHITECTURES_OF_INTENT_META.interactiveGuideHref}
-                target="_blank"
-                rel="noopener noreferrer"
-                className="case-study-cta case-study-cta--secondary"
-              >
-                {ARCHITECTURES_OF_INTENT_META.interactiveGuideLabel}{" "}
-                <span aria-hidden="true">↗</span>
-                <span className="sr-only"> (opens in a new tab)</span>
-              </a>
-            </div>
           </header>
 
           <article className="aoi-article mt-16">

--- a/app/research/page.tsx
+++ b/app/research/page.tsx
@@ -55,6 +55,8 @@ const SECTIONS = [
       "Systems-level product thinking",
     ],
     visual: "architectures-of-intent" as const,
+    detailHref: "/research/ai-native-strategy",
+    detailLabel: "Read the full research",
     externalHref: "https://v0-ai-native-strategy-research.vercel.app/",
     externalLabel: "Open interactive guide",
   },
@@ -204,16 +206,28 @@ export default function ResearchPage() {
               <ResearchStrategyVisuals variant={section.visual} />
             </div>
 
-            {"externalHref" in section && section.externalHref ? (
-              <a
-                href={section.externalHref}
-                target="_blank"
-                rel="noopener noreferrer"
-                className="mt-8 inline-flex font-ui text-[11px] uppercase tracking-[0.12em] text-[#31F5D4] transition-colors hover:text-[#7CE7D6] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#31F5D4]"
-              >
-                {section.externalLabel} ↗
-              </a>
-            ) : null}
+            <div className="mt-8 flex flex-wrap gap-4">
+              {"detailHref" in section && section.detailHref ? (
+                <Link
+                  href={section.detailHref}
+                  className="inline-flex font-ui text-[11px] uppercase tracking-[0.12em] text-[#31F5D4] transition-colors hover:text-[#7CE7D6] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#31F5D4]"
+                >
+                  {section.detailLabel} →
+                </Link>
+              ) : null}
+              {"externalHref" in section && section.externalHref ? (
+                <a
+                  href={section.externalHref}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="inline-flex font-ui text-[11px] uppercase tracking-[0.12em] text-[#A8B3B0] transition-colors hover:text-[#31F5D4] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#31F5D4]"
+                >
+                  {section.externalLabel}{" "}
+                  <span aria-hidden="true">↗</span>
+                  <span className="sr-only"> (opens in a new tab)</span>
+                </a>
+              ) : null}
+            </div>
           </section>
         ))}
 

--- a/components/ArchitecturesOfIntentVisuals.tsx
+++ b/components/ArchitecturesOfIntentVisuals.tsx
@@ -122,7 +122,7 @@ function SpectrumVisual() {
           </div>
         ))}
       </div>
-      <ol className="aoi-visual__sr-list">
+      <ol className="aoi-visual__sr-list" aria-hidden="true">
         {SPECTRUM_STAGES.map((stage) => (
           <li key={stage.label}>
             {stage.label}: {stage.sub}
@@ -141,11 +141,7 @@ function ArchetypesVisual() {
         Recurring jobs-to-be-done across AI-native products. Naming the job makes unlike systems
         comparable on the same terms.
       </p>
-      <div
-        className="aoi-visual__archetypes"
-        role="img"
-        aria-label="A map of seven AI-native experience archetypes arranged around a center labeled AI-native experience."
-      >
+      <div className="aoi-visual__archetypes">
         <div className="aoi-visual__archetype-center" aria-hidden="true">
           <span>AI-native experience</span>
         </div>
@@ -158,13 +154,6 @@ function ArchetypesVisual() {
           ))}
         </ul>
       </div>
-      <ol className="aoi-visual__sr-list">
-        {ARCHETYPES.map((item) => (
-          <li key={item.name}>
-            {item.name}: {item.job}
-          </li>
-        ))}
-      </ol>
     </figure>
   )
 }

--- a/components/ArchitecturesOfIntentVisuals.tsx
+++ b/components/ArchitecturesOfIntentVisuals.tsx
@@ -1,0 +1,226 @@
+/**
+ * Sanitized Architectures of Intent article visuals — abstract diagrams only.
+ * No product UI, logos, screenshots, metrics, or private information.
+ */
+
+type VisualVariant = "spectrum" | "archetypes" | "trust-loop"
+
+const SPECTRUM_STAGES = [
+  {
+    label: "AI-enabled",
+    sub: "Feature augmentation",
+    overlap: "bare",
+  },
+  {
+    label: "AI-first",
+    sub: "Intelligence-driven workflow",
+    overlap: "substantial",
+  },
+  {
+    label: "AI-native",
+    sub: "AI-dependent value loop",
+    overlap: "merged",
+  },
+] as const
+
+const ARCHETYPES = [
+  {
+    name: "Answer Engines",
+    job: "Return a direct, sourced answer instead of a list of results.",
+  },
+  {
+    name: "Enterprise Knowledge Assistants",
+    job: "Retrieve governed organizational knowledge across tools.",
+  },
+  {
+    name: "Agentic Developer Tools",
+    job: "Plan and prepare code changes across a codebase.",
+  },
+  {
+    name: "Customer and Service Agents",
+    job: "Resolve service requests or escalate with context.",
+  },
+  {
+    name: "Deep Research Agents",
+    job: "Synthesize multi-source analysis over an extended session.",
+  },
+  {
+    name: "Ambient and Context-Aware Assistants",
+    job: "Use memory or surrounding context to support continuity.",
+  },
+  {
+    name: "Workplace Copilots",
+    job: "Accelerate drafting, summarizing, finding, and editing inside existing work tools.",
+  },
+] as const
+
+const TRUST_LOOP = [
+  "Intent",
+  "Context & Grounding",
+  "Proposal",
+  "Evidence",
+  "Human Review",
+  "Authorized Action",
+  "Feedback / Recovery",
+] as const
+
+function SpectrumShapes({ overlap }: { overlap: "bare" | "substantial" | "merged" }) {
+  if (overlap === "merged") {
+    return (
+      <svg viewBox="0 0 120 72" className="aoi-visual__shapes" aria-hidden="true">
+        <ellipse cx="60" cy="36" rx="42" ry="26" fill="#31F5D4" fillOpacity="0.22" stroke="#31F5D4" strokeWidth="1.5" />
+        <ellipse cx="60" cy="36" rx="28" ry="18" fill="#7CE7D6" fillOpacity="0.18" stroke="#7CE7D6" strokeWidth="1" />
+      </svg>
+    )
+  }
+
+  const dx = overlap === "bare" ? 28 : 14
+  return (
+    <svg viewBox="0 0 120 72" className="aoi-visual__shapes" aria-hidden="true">
+      <ellipse
+        cx={60 - dx}
+        cy="36"
+        rx="30"
+        ry="22"
+        fill="#A8B3B0"
+        fillOpacity="0.12"
+        stroke="#A8B3B0"
+        strokeWidth="1.25"
+      />
+      <ellipse
+        cx={60 + dx}
+        cy="36"
+        rx="30"
+        ry="22"
+        fill="#31F5D4"
+        fillOpacity="0.2"
+        stroke="#31F5D4"
+        strokeWidth="1.25"
+      />
+    </svg>
+  )
+}
+
+function SpectrumVisual() {
+  return (
+    <figure className="aoi-visual aoi-visual--spectrum">
+      <figcaption className="aoi-visual__caption">AI-enabled → AI-first → AI-native</figcaption>
+      <p className="aoi-visual__blurb">
+        Depth of AI integration, not feature count: from barely overlapping systems, to substantial
+        overlap, to a merged value loop.
+      </p>
+      <div
+        className="aoi-visual__spectrum"
+        role="img"
+        aria-label="A three-stage diagram showing two shapes, one for the product and one for its AI, moving from barely touching, to significantly overlapping, to fully merged into one shape. The stages are labeled AI-enabled, AI-first, and AI-native."
+      >
+        {SPECTRUM_STAGES.map((stage) => (
+          <div key={stage.label} className="aoi-visual__spectrum-stage">
+            <SpectrumShapes overlap={stage.overlap} />
+            <p className="aoi-visual__stage-label">{stage.label}</p>
+            <p className="aoi-visual__stage-sub">{stage.sub}</p>
+          </div>
+        ))}
+      </div>
+      <ol className="aoi-visual__sr-list">
+        {SPECTRUM_STAGES.map((stage) => (
+          <li key={stage.label}>
+            {stage.label}: {stage.sub}
+          </li>
+        ))}
+      </ol>
+    </figure>
+  )
+}
+
+function ArchetypesVisual() {
+  return (
+    <figure className="aoi-visual aoi-visual--archetypes">
+      <figcaption className="aoi-visual__caption">AI-native experience archetype map</figcaption>
+      <p className="aoi-visual__blurb">
+        Recurring jobs-to-be-done across AI-native products. Naming the job makes unlike systems
+        comparable on the same terms.
+      </p>
+      <div
+        className="aoi-visual__archetypes"
+        role="img"
+        aria-label="A map of seven AI-native experience archetypes arranged around a center labeled AI-native experience."
+      >
+        <div className="aoi-visual__archetype-center" aria-hidden="true">
+          <span>AI-native experience</span>
+        </div>
+        <ul className="aoi-visual__archetype-list">
+          {ARCHETYPES.map((item) => (
+            <li key={item.name} className="aoi-visual__archetype-item">
+              <strong>{item.name}</strong>
+              <span>{item.job}</span>
+            </li>
+          ))}
+        </ul>
+      </div>
+      <ol className="aoi-visual__sr-list">
+        {ARCHETYPES.map((item) => (
+          <li key={item.name}>
+            {item.name}: {item.job}
+          </li>
+        ))}
+      </ol>
+    </figure>
+  )
+}
+
+function TrustLoopVisual() {
+  return (
+    <figure className="aoi-visual aoi-visual--trust-loop">
+      <figcaption className="aoi-visual__caption">
+        Intent → Context &amp; Grounding → Proposal → Evidence → Human Review → Authorized Action →
+        Feedback / Recovery
+      </figcaption>
+      <p className="aoi-visual__blurb">
+        A visible loop for trustworthy AI-native systems. Human Review is a designed checkpoint, not
+        an afterthought.
+      </p>
+      <ol
+        className="aoi-visual__loop"
+        aria-label="An ordered loop begins with Intent, moves to Context and Grounding, then Proposal, Evidence, Human Review, Authorized Action, and Feedback or Recovery. Feedback or Recovery returns to Intent or Context and Grounding. Human Review is marked as a distinct checkpoint."
+      >
+        {TRUST_LOOP.map((step, index) => {
+          const isReview = step === "Human Review"
+          return (
+            <li
+              key={step}
+              className={`aoi-visual__loop-step${isReview ? " aoi-visual__loop-step--review" : ""}`}
+            >
+              <span className="aoi-visual__loop-index" aria-hidden="true">
+                {index + 1}
+              </span>
+              <span className="aoi-visual__loop-label">
+                {step}
+                {isReview ? " — designed human checkpoint" : ""}
+              </span>
+              {index < TRUST_LOOP.length - 1 ? (
+                <span className="aoi-visual__loop-arrow" aria-hidden="true">
+                  →
+                </span>
+              ) : (
+                <span className="aoi-visual__loop-return" aria-hidden="true">
+                  ↻ returns to Intent / Context &amp; Grounding
+                </span>
+              )}
+            </li>
+          )
+        })}
+      </ol>
+    </figure>
+  )
+}
+
+export default function ArchitecturesOfIntentVisuals({
+  variant,
+}: {
+  variant: VisualVariant
+}) {
+  if (variant === "spectrum") return <SpectrumVisual />
+  if (variant === "archetypes") return <ArchetypesVisual />
+  return <TrustLoopVisual />
+}

--- a/content/architectures-of-intent-sources.ts
+++ b/content/architectures-of-intent-sources.ts
@@ -1,0 +1,124 @@
+/**
+ * Public-safe source list for Architectures of Intent.
+ * Titles and URLs from the approved public sources packet only.
+ */
+
+export type ArchitectureSourceLink = {
+  label: string
+  href: string
+}
+
+export type ArchitectureSource = {
+  id: string
+  number: number
+  title: string
+  publisher: string
+  links: ArchitectureSourceLink[]
+}
+
+export const ARCHITECTURES_OF_INTENT_SOURCES: ArchitectureSource[] = [
+  {
+    id: "source-1",
+    number: 1,
+    title: "Perplexity product overview",
+    publisher: "Perplexity",
+    links: [{ label: "Perplexity product overview", href: "https://www.perplexity.ai/hub" }],
+  },
+  {
+    id: "source-2",
+    number: 2,
+    title: "Cursor product overview",
+    publisher: "Anysphere",
+    links: [{ label: "Cursor product overview", href: "https://cursor.com/" }],
+  },
+  {
+    id: "source-3",
+    number: 3,
+    title: "GitHub Copilot cloud agent documentation",
+    publisher: "GitHub Docs",
+    links: [
+      {
+        label: "About GitHub Copilot cloud agent",
+        href: "https://docs.github.com/en/copilot/concepts/agents/cloud-agent/about-cloud-agent",
+      },
+      {
+        label: "Review output from Copilot",
+        href: "https://docs.github.com/en/copilot/how-tos/copilot-on-github/use-copilot-agents/review-copilot-output",
+      },
+    ],
+  },
+  {
+    id: "source-4",
+    number: 4,
+    title: "Introducing NotebookLM",
+    publisher: "Google",
+    links: [
+      {
+        label: "Introducing NotebookLM",
+        href: "https://blog.google/innovation-and-ai/technology/ai/notebooklm-google-ai/",
+      },
+    ],
+  },
+  {
+    id: "source-5",
+    number: 5,
+    title: "Glean enterprise AI search and security",
+    publisher: "Glean",
+    links: [
+      {
+        label: "Enterprise-grade generative AI search capabilities",
+        href: "https://www.glean.com/blog/search-launch-announcement",
+      },
+      {
+        label: "AI Security: Protecting Enterprise Data with Glean",
+        href: "https://www.glean.com/platform/security",
+      },
+    ],
+  },
+  {
+    id: "source-6",
+    number: 6,
+    title: "Data, Privacy, and Security for Microsoft 365 Copilot",
+    publisher: "Microsoft Learn",
+    links: [
+      {
+        label: "Data, Privacy, and Security for Microsoft 365 Copilot",
+        href: "https://learn.microsoft.com/en-us/microsoft-365/copilot/microsoft-365-copilot-privacy",
+      },
+    ],
+  },
+  {
+    id: "source-7",
+    number: 7,
+    title: "Agentforce: The AI Agent Platform",
+    publisher: "Salesforce",
+    links: [
+      {
+        label: "Agentforce: The AI Agent Platform",
+        href: "https://www.salesforce.com/agentforce/",
+      },
+    ],
+  },
+  {
+    id: "source-8",
+    number: 8,
+    title: "Fin: The highest performing Customer Agent",
+    publisher: "Intercom",
+    links: [{ label: "Fin: The highest performing Customer Agent", href: "https://fin.ai" }],
+  },
+  {
+    id: "source-9",
+    number: 9,
+    title: "Memory FAQ",
+    publisher: "OpenAI Help Center",
+    links: [
+      {
+        label: "Memory FAQ",
+        href: "https://help.openai.com/en/articles/8590148-memory-faq",
+      },
+    ],
+  },
+]
+
+export const ARCHITECTURES_OF_INTENT_PUBLICATION_NOTE =
+  "Product examples reflect publicly documented behavior reviewed during this research; interfaces and feature names may evolve."

--- a/content/architectures-of-intent.ts
+++ b/content/architectures-of-intent.ts
@@ -1,0 +1,271 @@
+/**
+ * Approved public article for Architectures of Intent.
+ * Locked copy from the final public edition — structural conversion only.
+ * Inline citations use {{n}} markers rendered as footnote links.
+ */
+
+export type ArticleBlock =
+  | { type: "p"; text: string }
+  | { type: "visual"; variant: "spectrum" | "archetypes" | "trust-loop" }
+  | { type: "principles" }
+
+export type ArticleSection = {
+  id: string
+  title: string
+  blocks: ArticleBlock[]
+}
+
+export const ARCHITECTURES_OF_INTENT_META = {
+  title: "Architectures of Intent",
+  subtitle: "What enterprise software becomes when AI is the operating model, not a feature",
+  eyebrow: "Research & Strategy",
+  metadataLine: "Research synthesis · Public edition · approximately 12-minute read",
+  abstract:
+    "The more meaningful question is what happens when AI stops being something a product has and starts becoming part of what the product is. The interface becomes something closer to a negotiation between what a person is trying to accomplish, what the system understands, what evidence it can show, and what it is allowed to do.",
+  wordCount: 2552,
+  interactiveGuideHref: "https://v0-ai-native-strategy-research.vercel.app/",
+  interactiveGuideLabel: "Open interactive guide",
+} as const
+
+export const ARCHITECTURES_OF_INTENT_TOC = [
+  { id: "opening-thesis", label: "Opening thesis" },
+  { id: "feature-layer-ai", label: "Why feature-layer AI is insufficient" },
+  { id: "remove-it-test", label: "The remove-it test" },
+  { id: "experience-archetypes", label: "AI-native experience archetypes" },
+  { id: "trust", label: "Trust as a designed product surface" },
+  { id: "grounding-and-evidence", label: "Context, grounding, and evidence" },
+  { id: "bounded-autonomy", label: "Permissions, review, and bounded autonomy" },
+  { id: "enterprise-implications", label: "Implications for complex enterprise work" },
+  { id: "design-practice", label: "How this research shaped my design practice" },
+  { id: "principles", label: "Principles teams can apply" },
+  { id: "closing-reflection", label: "Closing reflection" },
+  { id: "sources", label: "Sources and further reading" },
+] as const
+
+export const ARCHITECTURES_OF_INTENT_PRINCIPLES = [
+  "Apply the remove-it test before calling anything AI-native. Be honest about whether the product survives without its AI core, and design accordingly.",
+  "Make grounding visible. Show what the system is drawing from: a document, a workspace, a source set, the open web, or a governed enterprise graph.",
+  "Treat trust as a designed surface, not an assumption. Previews, rationales, diffs, and citations belong in the core interaction model.",
+  "Default to the lowest level of autonomy that still delivers value. Let the system earn the right to act through evidence, feedback, and well-designed constraints.",
+  "Give every consequential action a preview, a confirmation, and a reversal path or a clearly designed recovery or compensating action.",
+  "Design escalation to a person as a feature, with full context attached, not as a dead end the system reaches when it runs out of options.",
+  "Inherit permissions strictly. Never use AI to bypass the access and action boundaries that govern the person or workflow it represents.",
+  "Design the failure state before the happy path. The everyday, messy, ambiguous case is the real product; the clean demo case is not.",
+] as const
+
+export const ARCHITECTURES_OF_INTENT_SECTIONS: ArticleSection[] = [
+  {
+    id: "opening-thesis",
+    title: "Opening thesis",
+    blocks: [
+      {
+        type: "p",
+        text: "Much of enterprise software has historically been organized around predefined workflows, fixed navigation, and user-initiated steps. Define the workflow, design the screens, let people move through a fairly stable sequence of actions. When AI first entered that structure, it often appeared as a feature: a summary button, a drafting assistant, a smarter autocomplete, a chat panel added to the side of a product that otherwise worked the same way.",
+      },
+      {
+        type: "p",
+        text: "That phase is useful, but it is not the most interesting shift. The more meaningful question is what happens when AI stops being something a product has and starts becoming part of what the product is. The interface is no longer only a menu of things a person can click. It becomes something closer to a negotiation between what a person is trying to accomplish, what the system understands, what evidence it can show, and what it is allowed to do.",
+      },
+      {
+        type: "p",
+        text: "I have come to think of that shift as an architecture of intent: a system organized around interpreting and acting on human goals, rather than one organized only around a fixed set of functions. It is a design philosophy, not a feature list. The distance between those two things is larger than many product teams currently treat it.",
+      },
+    ],
+  },
+  {
+    id: "feature-layer-ai",
+    title: "Why feature-layer AI is insufficient",
+    blocks: [
+      {
+        type: "p",
+        text: "A large share of enterprise AI still behaves additively. It sits on top of an existing information architecture, with the same permissions model, the same navigation, and the same one-shot workflows, then tries to make that structure faster or more convenient: a draft here, a summary there, a suggestion in the corner of the screen.",
+      },
+      {
+        type: "p",
+        text: "That is a real improvement. It can remove busywork, reduce blank-page friction, and help people move faster through systems they already use. But additive AI inherits the assumptions of the product underneath it. If the workflow assumes a person will read every document, weigh every option, remember every dependency, and initiate every action by hand, a smart suggestion does not remove that assumption. It just makes the assumption less tedious to live with.",
+      },
+      {
+        type: "p",
+        text: "This matters because the advantage is moving. As access to capable models becomes less differentiating, more of the product advantage moves into context, grounding, workflow integration, and control-surface design. The better question is not which model sits behind a feature. It is what the product knows, what it can prove, where it can act, and how clearly a person can understand the boundary between suggestion and action.",
+      },
+      {
+        type: "p",
+        text: "Feature-layer AI rarely reaches all of that. It can make a product feel modern without changing the product's operating model. The harder work is architectural: redesigning the value loop so intelligence is not a decorative layer, but the thing that makes the work possible.",
+      },
+    ],
+  },
+  {
+    id: "remove-it-test",
+    title: "The remove-it test",
+    blocks: [
+      {
+        type: "p",
+        text: "The most useful filter to come out of this research is almost embarrassingly simple: remove the AI. What is left?",
+      },
+      {
+        type: "p",
+        text: "If the product gets worse but still does its job, that is AI-enabled. The workflow survives without the intelligence layer. If removing the AI breaks the primary workflow badly enough that the product would need to be redesigned around a person doing the work by hand, that is AI-first. And if removing the AI means the product has no reason to exist, with no meaningful manual equivalent left behind, that is AI-native.",
+      },
+      {
+        type: "p",
+        text: "Applied honestly, the test is uncomfortable. Under this test, I would classify many enterprise products, including some with serious AI investment behind them, as AI-enabled or AI-first rather than AI-native. A drafting assistant survives its own removal. A predictive dashboard survives too, just less impressively. A product like Perplexity is different: its core promise is a direct, cited answer assembled from sources, not a list of links with AI sprinkled on top.{{1}} Cursor is different in a related way: the product is built around an AI coding agent that can understand a codebase, plan work, and prepare changes for review.{{2}}",
+      },
+      {
+        type: "p",
+        text: "The point is not to shame the first two categories. Plenty of good software is, and should be, AI-enabled. The value of the remove-it test is honesty. It stops a team from calling something AI-native because it is ambitious, and makes them say plainly what actually depends on the intelligence layer and what is simply wrapped around it.",
+      },
+      { type: "visual", variant: "spectrum" },
+    ],
+  },
+  {
+    id: "experience-archetypes",
+    title: "AI-native experience archetypes",
+    blocks: [
+      {
+        type: "p",
+        text: "Across the products I reviewed, a small number of recurring jobs appeared again and again. The categories are not universal facts; they are how I organized the research so unlike products could be compared on the same terms.",
+      },
+      {
+        type: "p",
+        text: "Answer engines synthesize a direct, sourced answer instead of returning a list of results. Enterprise knowledge assistants retrieve and connect internal information across tools, with permissions and source visibility as part of the product. Agentic developer tools move from suggesting code to planning, editing, testing, and preparing changes across a codebase; GitHub Copilot's cloud agent, for example, can research a repository, create an implementation plan, make code changes on a branch, and let a person review the diff before a pull request is created.{{3}} Customer and service agents resolve requests by combining conversation, policy, records, and escalation. Deep research agents browse, read, and synthesize across many sources over an extended session. Ambient and context-aware assistants depend on memory and prior context, which makes transparency and user control especially important.{{9}} Workplace copilots sit inside existing work tools to accelerate drafting, summarizing, finding, and editing.",
+      },
+      {
+        type: "p",
+        text: "Most real products blend more than one archetype. That is fine. What matters is naming the job clearly: what is the user asking the system to do, and what happens to that job if the intelligence layer is removed?",
+      },
+      { type: "visual", variant: "archetypes" },
+    ],
+  },
+  {
+    id: "trust",
+    title: "Trust as a designed product surface",
+    blocks: [
+      {
+        type: "p",
+        text: "The biggest shift in how I think about AI products came from watching how differently trust behaves across this landscape. It does not map cleanly to model quality. Across the products I reviewed, trust appeared closely connected to a smaller set of design decisions: visible sources, previews before action, clear scope, inspectable changes, explicit limits, and a human path when the system should stop.",
+      },
+      {
+        type: "p",
+        text: "Perplexity and NotebookLM both make source grounding part of the experience, not an afterthought. NotebookLM's original product framing is especially direct: it grounds the model in the sources a person selects, accompanies responses with citations, and makes source checking part of the workflow.{{4}} GitHub Copilot and Cursor show a related pattern in a different medium: before code becomes part of the work, the change is made visible as something a person can inspect, reject, or revise.{{2}}{{3}}",
+      },
+      {
+        type: "p",
+        text: "None of that is just about the model getting smarter. It is about the product making its own reasoning and consequences inspectable: a preview before an action, a citation before a claim, a plan before execution, a review step before a change reaches a shared system. Trust is not something a person infers from a system that merely seems capable. It is something a team designs on purpose, the same way it would design an error state, checkout flow, or permission prompt.",
+      },
+      {
+        type: "p",
+        text: "Treat trust as an afterthought and people still calibrate it. They just calibrate it against the product's failures instead of against the product's intended boundaries.",
+      },
+    ],
+  },
+  {
+    id: "grounding-and-evidence",
+    title: "Context, grounding, and evidence",
+    blocks: [
+      {
+        type: "p",
+        text: "If trust is designed, grounding is what it is designed around. The products that hold up under sustained use are specific about two things: what the system knows, and how a person can check it.",
+      },
+      {
+        type: "p",
+        text: "NotebookLM makes the source boundary central to the product: answers are grounded in the sources the user selects, and citations help people check the relevant original material.{{4}} Microsoft 365 Copilot frames grounding through Microsoft Graph and the user's working context, while stating that Copilot only surfaces organizational data the person has permission to view.{{6}} Glean describes a similar enterprise pattern from another angle: company context, data governance, permission boundaries, and referenceability are not separate compliance details; they are the foundation that makes AI answers usable in an organization.{{5}}",
+      },
+      {
+        type: "p",
+        text: "What all three are doing is turning \"what does the AI know\" from an implementation detail into a visible part of the product. That distinction matters more in enterprise work than in casual use. Consumer AI products often optimize for speed and delight. Enterprise systems must deliver those qualities while also being defensible, permission-aware, and traceable.",
+      },
+      {
+        type: "p",
+        text: "An ungrounded answer that sounds confident can propagate into consequential decisions, downstream systems, and other people's work. Evidence cannot be an afterthought. It has to be load-bearing: a citation someone can open, a scope they can see, a source they can trace, a recommendation they can challenge.",
+      },
+    ],
+  },
+  {
+    id: "bounded-autonomy",
+    title: "Permissions, review, and bounded autonomy",
+    blocks: [
+      {
+        type: "p",
+        text: "In this research, I found that the frontier has moved from AI that suggests to AI that acts. That transition is where much of the real design work now lives. Suggesting a sentence is low stakes. Editing a file across a codebase, resolving a customer issue, updating a record, or advancing a workflow is not.",
+      },
+      {
+        type: "p",
+        text: "The stronger products share a pattern: a visible plan before execution, a preview of consequences, a confirmation step that explains what is about to happen, and a reversal path or clearly designed recovery or compensating action when something goes wrong. GitHub's cloud-agent workflow keeps code changes on a branch, exposes review through the pull request system, and treats review of agent output as normal engineering work.{{3}} Salesforce describes Agentforce as a platform for building, testing, deploying, managing, and supervising agents, with guardrails, testing, and human handoff as part of the agent lifecycle.{{7}} Intercom's Fin positions handoff to a human team, full customer context, testing, and observability as core parts of how a service agent should operate.{{8}}",
+      },
+      {
+        type: "p",
+        text: "Underneath all of this sits a rule simple enough to state plainly: An AI system should not exceed the user's authorized access or the authority explicitly delegated to it by policy. Permissions inherit. Autonomy is earned in stages, not granted by default. Review is not friction to be engineered away. It is the mechanism that makes bounded autonomy credible enough for work that matters.",
+      },
+      { type: "visual", variant: "trust-loop" },
+    ],
+  },
+  {
+    id: "enterprise-implications",
+    title: "Implications for complex enterprise work",
+    blocks: [
+      {
+        type: "p",
+        text: "Much of my work sits inside complex enterprise workflows where decisions cross systems, stakeholders, permissions, and real operational consequences.",
+      },
+      {
+        type: "p",
+        text: "That context changes what feels important in this research. The remove-it test, visible grounding, and bounded autonomy are not just elegant design patterns. They become preconditions for whether an intelligent system should be trusted with anything consequential. In a complex workflow, an error may not stay local to one screen or one person. It may move into a downstream system, shape another person's judgment, trigger follow-up work, or become part of a record someone else relies on later.",
+      },
+      {
+        type: "p",
+        text: "What I take from this is that AI-native design in complex enterprise domains is not primarily about autonomy for its own sake. It is about making complexity legible: giving someone enough visible reasoning, evidence, and control that they can move forward with judgment instead of simply accepting an answer and hoping it holds up.",
+      },
+    ],
+  },
+  {
+    id: "design-practice",
+    title: "How this research shaped my design practice",
+    blocks: [
+      {
+        type: "p",
+        text: "This research shaped how I approach information architecture, trust, evidence, human review, and governed action in complex enterprise products.",
+      },
+      {
+        type: "p",
+        text: "The research gave me a more consistent set of questions to bring into early product work: what breaks without the intelligence layer, what evidence supports a recommendation, where human review belongs, and how clearly the system communicates the limits of its context.",
+      },
+      {
+        type: "p",
+        text: "Concretely, that means I ask the remove-it question earlier now, before a feature is scoped rather than after it is built. I treat \"why is it suggesting this\" as a first-order product question, not an edge case. I think about review and escalation before the happy path, because the moment something goes wrong often determines whether people keep using the system. And I treat grounding scope, what the system is and is not drawing from, as something a person should see at a glance.",
+      },
+      {
+        type: "p",
+        text: "None of that makes for a dramatic before-and-after story. It is a shift in what I check for first. It has held up across enough product problems that I no longer think of it only as a research conclusion. It is how I work now.",
+      },
+    ],
+  },
+  {
+    id: "principles",
+    title: "Principles teams can apply",
+    blocks: [
+      {
+        type: "p",
+        text: "A few principles came out of this research clearly enough that I would hand them to any team building an AI-native product, regardless of domain:",
+      },
+      { type: "principles" },
+    ],
+  },
+  {
+    id: "closing-reflection",
+    title: "Closing reflection",
+    blocks: [
+      {
+        type: "p",
+        text: "I keep coming back to the phrase architecture of intent because it names the design problem correctly. The interesting work is not making a model sound more impressive or an interface feel more magical. It is building the structure around it: grounding, evidence, review, boundaries, recovery, and permission-aware action.",
+      },
+      {
+        type: "p",
+        text: "Software has faced smaller versions of this problem before, every time a new capability needed new guardrails before people would rely on it. This version is larger because the system can now interpret intent and act across real workflows. I do not think the industry has solved that yet. I have not solved it either. But I know what I am looking for now when I try.",
+      },
+      {
+        type: "p",
+        text: "Not a more impressive answer. A structure I would trust with a decision that actually matters.",
+      },
+    ],
+  },
+]

--- a/content/architectures-of-intent.ts
+++ b/content/architectures-of-intent.ts
@@ -146,7 +146,7 @@ export const ARCHITECTURES_OF_INTENT_SECTIONS: ArticleSection[] = [
       },
       {
         type: "p",
-        text: "Perplexity and NotebookLM both make source grounding part of the experience, not an afterthought. NotebookLM's original product framing is especially direct: it grounds the model in the sources a person selects, accompanies responses with citations, and makes source checking part of the workflow.{{4}} GitHub Copilot and Cursor show a related pattern in a different medium: before code becomes part of the work, the change is made visible as something a person can inspect, reject, or revise.{{2}}{{3}}",
+        text: "Perplexity and NotebookLM both make source grounding part of the experience, not an appendix. NotebookLM's original product framing is especially direct: it grounds the model in the sources a person selects, accompanies responses with citations, and makes source checking part of the workflow.{{4}} GitHub Copilot and Cursor show a related pattern in a different medium: before code becomes part of the work, the change is made visible as something a person can inspect, reject, or revise.{{2}}{{3}}",
       },
       {
         type: "p",
@@ -176,7 +176,7 @@ export const ARCHITECTURES_OF_INTENT_SECTIONS: ArticleSection[] = [
       },
       {
         type: "p",
-        text: "An ungrounded answer that sounds confident can propagate into consequential decisions, downstream systems, and other people's work. Evidence cannot be an afterthought. It has to be load-bearing: a citation someone can open, a scope they can see, a source they can trace, a recommendation they can challenge.",
+        text: "An ungrounded answer that sounds confident can propagate into consequential decisions, downstream systems, and other people's work. Evidence cannot be an appendix. It has to be load-bearing: a citation someone can open, a scope they can see, a source they can trace, a recommendation they can challenge.",
       },
     ],
   },

--- a/content/ask-ardavan.ts
+++ b/content/ask-ardavan.ts
@@ -115,6 +115,10 @@ export const ASK_ARDAVAN_PROMPTS: AskArdavanPrompt[] = [
       "I create strategic research and operating models that help teams make sense of AI-native product work. Recent public-safe examples include an AI-native strategy guide, a GitHub-based collaboration model for integrated prototype work, and research on platform patterns like context, grounding, trust, review, permissions, human control, and moving from suggestion to action.",
     links: [
       {
+        label: "Read Architectures of Intent",
+        href: "/research/ai-native-strategy",
+      },
+      {
         label: "View Research & Strategy",
         href: "/research",
       },

--- a/content/research.ts
+++ b/content/research.ts
@@ -44,8 +44,10 @@ export const RESEARCH_ENTRIES: ResearchEntry[] = [
       "Research synthesis",
     ],
     status: "Public research artifact",
-    href: "/research#architectures-of-intent",
-    ctaLabel: "View research summary",
+    href: "/research/ai-native-strategy",
+    ctaLabel: "Read the research",
+    externalHref: "https://v0-ai-native-strategy-research.vercel.app/",
+    externalCtaLabel: "Open interactive guide",
   },
   {
     id: "github-design-collaboration",

--- a/docs/sot/architectures-of-intent-publication-sot.md
+++ b/docs/sot/architectures-of-intent-publication-sot.md
@@ -1,0 +1,106 @@
+# Architectures of Intent — Publication SOT
+
+Version: 1.0  
+Last updated: 2026-07-12  
+Status: Public-safe · Sprint 9A implemented (pending PR review)
+
+## Publication title
+
+Architectures of Intent
+
+## Route
+
+`/research/ai-native-strategy`
+
+Canonical: `https://www.ardavanmir.com/research/ai-native-strategy`
+
+## Purpose
+
+Publish a public-safe research essay exploring what enterprise software becomes when AI shifts from feature layer to operating model, with emphasis on context, grounding, evidence, permissions, human review, and governed action.
+
+## Approved article source
+
+Locked public article edition used for Sprint 9A implementation. Site conversion preserves section order, paragraph order, numbered principles, endnotes, and the publication note. No substantive rewrite.
+
+Final article word count (approved packet): **2,552 words**.
+
+## Approved visual source
+
+Final visual brief for three abstract diagrams:
+
+1. AI-enabled → AI-first → AI-native spectrum
+2. AI-native experience archetype map
+3. Intent → Context & Grounding → Proposal → Evidence → Human Review → Authorized Action → Feedback / Recovery loop
+
+## Public-source verification status
+
+Nine public endnotes verified against official product pages and documentation in the approved public sources list. All endnote URLs are live official sources.
+
+## Public treatment
+
+- Full essay at `/research/ai-native-strategy`
+- Summary + detail CTA on `/research`
+- Homepage Research card routes to the detail page
+- Ask Ardavan research answer links to the detail page first, then `/research`
+- Interactive guide remains an external secondary link (not on homepage)
+- Global OG image reused; no route-specific OG image in Sprint 9A
+
+## Implementation files
+
+- `app/research/ai-native-strategy/page.tsx`
+- `components/ArchitecturesOfIntentVisuals.tsx`
+- `content/architectures-of-intent.ts`
+- `content/architectures-of-intent-sources.ts`
+- Discovery updates: `content/research.ts`, `content/ask-ardavan.ts`, `app/research/page.tsx`
+- Styles: `app/globals.css`
+
+## Accessibility requirements
+
+- One `h1`
+- Logical `h2` section hierarchy
+- Accessible “On this page” navigation label
+- Adequate scroll-margin for anchors
+- External links indicated and open with `rel="noopener noreferrer"`
+- Keyboard-accessible footnote references and source links
+- Visuals use `figure` / `figcaption` and descriptive `aria-label` or ordered text alternatives
+- Human Review distinction uses text as well as color
+- Focus-visible styles and reduced-motion respect
+
+## Mobile requirements
+
+- No horizontal page overflow
+- Reading column remains readable
+- ToC is a static block on small screens (sticky only on large screens)
+- Spectrum stacks vertically
+- Archetype map becomes a vertical list
+- Trust loop becomes a vertical flow
+- Long source URLs wrap cleanly
+
+## Confidentiality boundaries
+
+Do not publish:
+
+- Private colleague names or quotes
+- Internal product acronyms beyond already public portfolio usage
+- Customer names
+- Metrics
+- Launch, shipped, adoption, revenue, or company-decision claims
+- Unsupported ownership verbs
+- Raw research archive material
+- Private claims maps, redaction logs, or review reports
+- Absolute local paths or Drive links
+
+Safe relationship wording for related IES work:
+
+“This research and the IES case study share a focus on making complex systems legible through evidence, trust, review, and human judgment.”
+
+## Maintenance note
+
+Product examples reflect publicly documented behavior reviewed during this research; interfaces and feature names may evolve. Re-check source URLs if a future refresh is needed.
+
+## Future optional enhancements
+
+- Route-specific OG image
+- Deeper interactive embeds (still external unless separately approved)
+- Additional research detail pages for other tracks
+- Optional removal of deprecated OG assets elsewhere on the site

--- a/docs/sot/changelog.md
+++ b/docs/sot/changelog.md
@@ -1,5 +1,15 @@
 # Portfolio Changelog (Sprint Docs)
 
+## 2026-07-12 — Sprint 9A — Architectures of Intent public research article
+
+- Published public-safe Architectures of Intent essay at `/research/ai-native-strategy`
+- Converted locked approved article into typed content source (no new Markdown/MDX dependency)
+- Added nine verified public endnotes and source list
+- Added three sanitized abstract visuals (spectrum, archetype map, trust loop)
+- Updated Research index, homepage research card href, and Ask Ardavan research links
+- Added publication SOT and updated research, roadmap, claims, and visual-plan docs
+- No raw research, private claims map, redaction log, review report, résumé, CNAME, deploy, or dependency changes
+
 ## 2026-07-11 — Log final share-preview validation results
 
 - Logged final manual share-preview validation results after OG image v2 fix.

--- a/docs/sot/portfolio-claims-log.md
+++ b/docs/sot/portfolio-claims-log.md
@@ -1,11 +1,12 @@
 # Portfolio Claims Log
 
-Version: 1.8  
-Last updated: 2026-07-11  
+Version: 1.9  
+Last updated: 2026-07-12  
 Status: Public-safe
 
 | Claim | Status | Public wording | Notes |
 |-------|--------|----------------|-------|
+| Architectures of Intent public research article | PUBLIC_SAFE | A research essay exploring what enterprise software becomes when AI shifts from feature layer to operating model, with emphasis on context, grounding, evidence, permissions, human review, and governed action. | Live at `/research/ai-native-strategy`. Do not add internal influence, launch, adoption, or company-decision claims. |
 | Ardavan designs AI-native enterprise products that make financial complexity legible. | PUBLIC_SAFE | I design AI-native enterprise products that make financial complexity legible. | Current homepage positioning. |
 | IES work involved AI-native enterprise finance direction. | PUBLIC_SAFE (conservative) | Helped define and communicate AI-native product direction for complex enterprise finance workflows. | Use “helped define and communicate,” not “led” or “launched.” |
 | IES work involved IA, workflow clarity, trust, evidence, authorization, human judgment, prototype direction, and leadership storytelling. | PUBLIC_SAFE when abstracted | The work focused on making complex financial workflows clearer through information architecture, trust patterns, evidence, human judgment, prototypes, and product storytelling. | Do not name internal frameworks or prototypes. |

--- a/docs/sot/portfolio-roadmap.md
+++ b/docs/sot/portfolio-roadmap.md
@@ -1,7 +1,7 @@
 # Portfolio Roadmap
 
-Version: 1.8  
-Last updated: 2026-07-11  
+Version: 1.9  
+Last updated: 2026-07-12  
 Status: Public-safe
 
 ## Current status
@@ -14,7 +14,8 @@ Status: Public-safe
 - QBOA public-safe case study is live at `/work/quickbooks-dimensional-chart-of-accounts` (visual polish in Sprint 6)
 - OG image, favicon, and share metadata are live (Sprint 3.2)
 - Executive storytelling proof layer homepage section is live (Sprint 4)
-- Research & Strategy layer in progress (Sprint 8)
+- Research & Strategy layer live (Sprint 8)
+- Architectures of Intent full essay implemented at `/research/ai-native-strategy` (Sprint 9A — pending PR review)
 
 ## Priority order
 
@@ -163,10 +164,27 @@ The portfolio already has product case-study depth through IES and QBOA. The nex
 
 - P2 — GitHub-Based Design Collaboration detail page
 - P2 — AI-Native Platform Patterns detail page / pattern library
-- P2 — Architectures of Intent deeper page or external link
+- ~~P2 — Architectures of Intent deeper page or external link~~ → **Sprint 9A implemented** (`/research/ai-native-strategy`)
 - P2 — Research artifact visuals
 - P3 — Publish excerpts only if approved
 - P3 — Add research links to résumé only if verified and relevant
+
+## Sprint 9A — Architectures of Intent public research article — **Implemented (pending PR review)**
+
+Delivered:
+
+- Public essay route `/research/ai-native-strategy`
+- Locked approved article converted to typed content source (no MDX dependency)
+- Nine verified public endnotes and source list
+- Three sanitized visuals (spectrum, archetype map, trust loop)
+- Research index, homepage card, and Ask Ardavan discovery links
+- Publication SOT (`architectures-of-intent-publication-sot.md`)
+
+Still deferred:
+
+- Route-specific OG image for the essay
+- Other research detail pages
+- Apex DNS/TLS fix (outside repo)
 
 ## Next sprint candidate — Portfolio maintenance
 

--- a/docs/sot/research-strategy-sot.md
+++ b/docs/sot/research-strategy-sot.md
@@ -23,6 +23,8 @@ This work shows Ardavan contributing to the operating models, frameworks, and re
 **Public-safe summary:**  
 A public AI-native strategy guide exploring what enterprise software becomes when AI stops being treated as a feature and starts becoming the operating model.
 
+**Live route:** `/research/ai-native-strategy` (Sprint 9A)
+
 **What it proves:**
 
 - AI-native product strategy
@@ -38,6 +40,8 @@ A public AI-native strategy guide exploring what enterprise software becomes whe
 - Intelligence-as-infrastructure map
 - “Feature → operating model” transition model
 - Architecture-of-intent visual
+- Full public essay (implemented)
+- Spectrum, archetype map, and trust-loop visuals (implemented)
 
 ### Track 2: GitHub-Based Design Collaboration
 

--- a/docs/sot/sanitized-visual-plan.md
+++ b/docs/sot/sanitized-visual-plan.md
@@ -126,3 +126,18 @@ Implemented in `components/ResearchStrategyVisuals.tsx`:
 - No internal repo names
 - No internal team names
 - No metrics
+
+## Architectures of Intent article visuals (Sprint 9A — implemented)
+
+Implemented in `components/ArchitecturesOfIntentVisuals.tsx`:
+
+1. **AI-enabled → AI-first → AI-native spectrum**  
+   Two abstract shapes move from barely overlapping, to substantially overlapping, to merged.  
+   Labels: AI-enabled / Feature augmentation; AI-first / Intelligence-driven workflow; AI-native / AI-dependent value loop
+
+2. **AI-native experience archetype map**  
+   Center: AI-native experience. Surrounding archetypes with generic job descriptions only (no product names).
+
+3. **Trust / autonomy loop**  
+   Intent → Context & Grounding → Proposal → Evidence → Human Review → Authorized Action → Feedback / Recovery  
+   Human Review is visually and textually distinct; Feedback / Recovery returns to Intent or Context & Grounding.


### PR DESCRIPTION
## Summary
Publishes the public-safe Architectures of Intent research essay at /research/ai-native-strategy.

## Included
- Full approved research article
- Nine verified public endnotes
- Three sanitized abstract visuals
- Accessible table of contents and article structure
- Research, homepage-card, and Ask Ardavan links
- Metadata and canonical URL
- Research SOT updates

## Safety
- No raw research committed
- No private claims map committed
- No redaction log committed
- No private review report committed
- No internal names, screenshots, repo names, customers, metrics, or Drive links
- No launch/adoption/revenue claims
- No résumé changes
- No deployment changes
- No dependencies

## QA
- pnpm build passed
- Static export includes /research/ai-native-strategy
- Mobile and reduced-motion behavior verified
- Public-safety search passed

Made with [Cursor](https://cursor.com)